### PR TITLE
feat: discharge issues #10 and #11 in full

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,28 +9,55 @@ and this project follows [Semantic Versioning](https://semver.org/).
 
 ### Added
 
-- **Typed IOTCM command builder finalized (issue #10).** The IOTCM
+- **Typed IOTCM command builder — issue #10 closed.** The IOTCM
   transport envelope (`IOTCM "<file>" NonInteractive Direct (...)`)
   is now built through a single `iotcmEnvelope` helper in
   `src/protocol/command-builder.ts`; `AgdaSession.iotcm`,
   `iotcmFor`, and `runIndependentCommand` all delegate to it, so the
-  envelope shape is no longer hand-assembled in two duplicate
-  template literals inside `session.ts`. The last bare-string inner
-  command (`Cmd_show_version`) now goes through `topLevelCommand`,
-  matching the rest of the surface. Property-based tests cover
-  escaping (`quoted`/`stringList`), `noRange` placement for goal
-  builders, and round-tripping of arbitrary inner commands through
-  `iotcmEnvelope`.
-- **Output-schema and completeness invariants (issue #11).** A new
-  unit suite at `test/unit/tools/output-schema-invariants.test.ts`
-  registers the full core tool surface and asserts that every
-  exposed tool declares a non-empty output schema with typed fields,
-  closing the regression hole where a tool could be registered with
-  an empty `z.object({})`. The same suite pins the load/typecheck
-  agreement contract: identical underlying signal must yield
-  identical completeness classification (`ok-complete`,
-  `ok-with-holes`, `type-error`) regardless of which entry point
-  produced the result.
+  envelope shape is no longer hand-assembled in duplicate template
+  literals inside `session.ts`. Every remaining bare-string inner
+  command — `Cmd_show_version`, `Cmd_abort`, `Cmd_exit`,
+  `ToggleImplicitArgs`, `ToggleIrrelevantArgs` — now goes through
+  the typed `topLevelCommand` / `command` builders. Property-based
+  tests in `test/property/protocol/command-builder.property.test.ts`
+  cover escaping (`quoted` / `stringList`), `noRange` placement for
+  goal builders, and round-tripping of arbitrary inner commands
+  through `iotcmEnvelope`. A regression fence at
+  `test/unit/protocol/no-bare-command-strings.test.ts` walks the
+  source tree and fails if any file outside the builder reintroduces
+  hand-assembled IOTCM envelopes or bare-string `Cmd_…` literals
+  passed into `iotcm` / `sendCommand` / `runControl` /
+  `runIndependentCommand`.
+- **Structured output rollout for every text tool — issue #11
+  closed.** Every previously text-only tool (33 in total —
+  `agda_apply_edit`, `agda_auto`, `agda_auto_all`, `agda_backend_*`,
+  `agda_case_split`, `agda_check_postulates`, `agda_compile`,
+  `agda_constraints`, `agda_context`, `agda_elaborate`,
+  `agda_give`, `agda_goal`, `agda_goal_analysis`, `agda_goal_type`,
+  `agda_goal_type_context_*`, `agda_helper_function`,
+  `agda_highlight`, `agda_intro`, `agda_list_modules`,
+  `agda_load_highlighting_info`, `agda_proof_status`,
+  `agda_read_module`, `agda_refine`, `agda_refine_exact`,
+  `agda_reload`, `agda_search_definitions`, `agda_show_implicit_args`,
+  `agda_show_irrelevant_args`, `agda_solve_all`, `agda_solve_one`,
+  `agda_term_search`, `agda_toggle_implicit_args`,
+  `agda_toggle_irrelevant_args`, `agda_token_highlighting`) now
+  emits a richer structured payload alongside its text rendering —
+  display-state snapshots for the toggle/show family, parsed solve
+  solutions and `rawSolutions`, structured `clauses` for case-split,
+  `goalType` / `context` arrays for goal queries, `success` /
+  `output` for backends, classification + goal diff for `agda_reload`,
+  pagination metadata for module/definition search, and so on. To
+  make enrichment a 2-3 line change instead of a full rewrite,
+  `registerTextTool` and `registerGoalTextTool` now accept a
+  callback returning either a bare string (legacy path) or an
+  `{ text, data }` pair; the wrapper merges `data` into the envelope
+  alongside the canonical `text` field. A new invariant test asserts
+  that every exposed tool exposes at least one structured field
+  beyond `text` / `goalId`, and the load/typecheck agreement
+  contract is pinned across `ok-complete` / `ok-with-holes` /
+  `type-error` so completeness fields cannot drift between entry
+  points.
 - **Declared supported-Agda range (issue #41 part 2).** A new
   `agdaMcpServer` block in `package.json` records `minAgdaVersion`
   and `maxTestedAgdaVersion`. The server now (a) emits a stderr

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,28 @@ and this project follows [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- **Typed IOTCM command builder finalized (issue #10).** The IOTCM
+  transport envelope (`IOTCM "<file>" NonInteractive Direct (...)`)
+  is now built through a single `iotcmEnvelope` helper in
+  `src/protocol/command-builder.ts`; `AgdaSession.iotcm`,
+  `iotcmFor`, and `runIndependentCommand` all delegate to it, so the
+  envelope shape is no longer hand-assembled in two duplicate
+  template literals inside `session.ts`. The last bare-string inner
+  command (`Cmd_show_version`) now goes through `topLevelCommand`,
+  matching the rest of the surface. Property-based tests cover
+  escaping (`quoted`/`stringList`), `noRange` placement for goal
+  builders, and round-tripping of arbitrary inner commands through
+  `iotcmEnvelope`.
+- **Output-schema and completeness invariants (issue #11).** A new
+  unit suite at `test/unit/tools/output-schema-invariants.test.ts`
+  registers the full core tool surface and asserts that every
+  exposed tool declares a non-empty output schema with typed fields,
+  closing the regression hole where a tool could be registered with
+  an empty `z.object({})`. The same suite pins the load/typecheck
+  agreement contract: identical underlying signal must yield
+  identical completeness classification (`ok-complete`,
+  `ok-with-holes`, `type-error`) regardless of which entry point
+  produced the result.
 - **Declared supported-Agda range (issue #41 part 2).** A new
   `agdaMcpServer` block in `package.json` records `minAgdaVersion`
   and `maxTestedAgdaVersion`. The server now (a) emits a stderr

--- a/src/agda/advanced-queries.ts
+++ b/src/agda/advanced-queries.ts
@@ -208,7 +208,7 @@ export async function autoAll(ctx: AgdaCommandContext): Promise<AutoResult> {
 export async function showVersion(
   ctx: AgdaCommandContext,
 ): Promise<ShowVersionResult> {
-  const responses = await ctx.sendCommand(ctx.iotcm("Cmd_show_version"));
+  const responses = await ctx.sendCommand(ctx.iotcm(topLevelCommand("Cmd_show_version")));
   throwOnFatalProtocolStderr(responses);
   const version =
     decodeDisplayTextResponses(responses, {

--- a/src/agda/agda-version-detection.ts
+++ b/src/agda/agda-version-detection.ts
@@ -16,7 +16,16 @@ import { decodeDisplayTextResponses } from "../protocol/responses/text-display.j
 import { type AgdaVersion, parseAgdaVersion } from "./agda-version.js";
 import { logger } from "./logger.js";
 import type { AgdaTransport } from "../session/agda-transport.js";
+import { topLevelCommand } from "../protocol/command-builder.js";
 import type { AgdaResponse } from "./types.js";
+
+/**
+ * Inner Agda command for the version probe. Materialized once so the
+ * regression fence in `test/unit/protocol/no-bare-command-strings.ts`
+ * doesn't have to special-case the call site, and so the typed builder
+ * remains the single source of truth for the wire string.
+ */
+const SHOW_VERSION_COMMAND = topLevelCommand("Cmd_show_version");
 
 /**
  * Hard cap on how many `Cmd_show_version` round-trips a session will
@@ -79,7 +88,7 @@ export async function preflightVersionDetection(args: {
 
   args.state.versionDetectionAttempts++;
   try {
-    const vCmd = args.buildIotcm("Cmd_show_version");
+    const vCmd = args.buildIotcm(SHOW_VERSION_COMMAND);
     const responses = await args.transport.sendCommand(
       args.proc,
       vCmd,

--- a/src/agda/completeness.ts
+++ b/src/agda/completeness.ts
@@ -36,6 +36,29 @@ function isCompletenessClassification(
 }
 
 /**
+ * Count-only classification primitive — does no array work and never
+ * allocates. Both the public `classifyCompleteness` (which takes a
+ * goals array) and the merged-result fallback path call this so they
+ * agree by construction and can both stay O(1) regardless of how
+ * many goals the caller is reporting.
+ */
+function classifyFromCounts(
+  success: boolean,
+  goalCount: number,
+  invisibleGoalCount: number,
+): CompletenessStatus {
+  const hasHoles = goalCount > 0 || invisibleGoalCount > 0;
+  const isComplete = success && !hasHoles;
+  return {
+    classification: success ? (hasHoles ? "ok-with-holes" : "ok-complete") : "type-error",
+    goalCount,
+    invisibleGoalCount,
+    hasHoles,
+    isComplete,
+  };
+}
+
+/**
  * Recompute completeness from the protocol-level counts alone.
  *
  * This is the count-only path: it knows about visible + invisible
@@ -50,22 +73,11 @@ function isCompletenessClassification(
 export function classifyCompleteness(
   input: CompletenessInput,
 ): CompletenessStatus {
-  const goalCount = input.goals.length;
-  const invisibleGoalCount = input.invisibleGoalCount ?? 0;
-  const hasHoles = goalCount > 0 || invisibleGoalCount > 0;
-  const isComplete = input.success && !hasHoles;
-
-  return {
-    classification: input.success
-      ? hasHoles
-        ? "ok-with-holes"
-        : "ok-complete"
-      : "type-error",
-    goalCount,
-    invisibleGoalCount,
-    hasHoles,
-    isComplete,
-  };
+  return classifyFromCounts(
+    input.success,
+    input.goals.length,
+    input.invisibleGoalCount ?? 0,
+  );
 }
 
 interface MergedCompletenessFields {
@@ -85,9 +97,13 @@ interface MergedCompletenessFields {
  * Agda-reported counts. Honor those fields directly so callers see
  * the same classification the load tool surfaced.
  *
- * Falls back to the count-only `classifyCompleteness` if the embedded
+ * Falls back to the count-only `classifyFromCounts` if the embedded
  * `classification` is missing or unknown — defensive for stub results
- * tests construct without populating the merged fields.
+ * tests construct without populating the merged fields. The fallback
+ * is O(1) and never materializes an array; an earlier draft of this
+ * helper used `new Array(goalCount)` to round-trip through
+ * `classifyCompleteness`, which would have allocated proportionally
+ * to a malformed result's reported `goalCount`.
  */
 function completenessFromMerged(
   result: MergedCompletenessFields,
@@ -101,11 +117,11 @@ function completenessFromMerged(
       isComplete: result.isComplete,
     };
   }
-  return classifyCompleteness({
-    success: result.success,
-    goals: new Array(result.goalCount),
-    invisibleGoalCount: result.invisibleGoalCount,
-  });
+  return classifyFromCounts(
+    result.success,
+    result.goalCount,
+    result.invisibleGoalCount,
+  );
 }
 
 export function completenessFromLoadResult(

--- a/src/agda/completeness.ts
+++ b/src/agda/completeness.ts
@@ -23,6 +23,30 @@ interface CompletenessInput {
   invisibleGoalCount?: number;
 }
 
+const CLASSIFICATIONS: ReadonlySet<CompletenessClassification> = new Set([
+  "ok-complete",
+  "ok-with-holes",
+  "type-error",
+]);
+
+function isCompletenessClassification(
+  value: string,
+): value is CompletenessClassification {
+  return CLASSIFICATIONS.has(value as CompletenessClassification);
+}
+
+/**
+ * Recompute completeness from the protocol-level counts alone.
+ *
+ * This is the count-only path: it knows about visible + invisible
+ * goals reported by Agda but cannot see source-only hole markers
+ * (`{!!}` / `?` / `{! expr !}` inside `abstract` blocks where Agda
+ * under-reports invisible goals — see the v0.6.6 bug bundle for
+ * `agda_load_no_metas`). Use this for raw protocol shapes; for a
+ * `LoadResult` / `TypeCheckResult` that already encodes the merged
+ * source+protocol signal, prefer the helpers below so the merged
+ * classification round-trips faithfully.
+ */
 export function classifyCompleteness(
   input: CompletenessInput,
 ): CompletenessStatus {
@@ -44,14 +68,54 @@ export function classifyCompleteness(
   };
 }
 
+interface MergedCompletenessFields {
+  success: boolean;
+  goalCount: number;
+  invisibleGoalCount: number;
+  hasHoles: boolean;
+  isComplete: boolean;
+  classification: string;
+}
+
+/**
+ * Build a `CompletenessStatus` from a result whose `hasHoles` /
+ * `isComplete` / `classification` fields already encode the merged
+ * source+protocol signal — i.e. `LoadResult` and `TypeCheckResult`
+ * after the load pipeline has fused source-hole scanning with the
+ * Agda-reported counts. Honor those fields directly so callers see
+ * the same classification the load tool surfaced.
+ *
+ * Falls back to the count-only `classifyCompleteness` if the embedded
+ * `classification` is missing or unknown — defensive for stub results
+ * tests construct without populating the merged fields.
+ */
+function completenessFromMerged(
+  result: MergedCompletenessFields,
+): CompletenessStatus {
+  if (isCompletenessClassification(result.classification)) {
+    return {
+      classification: result.classification,
+      goalCount: result.goalCount,
+      invisibleGoalCount: result.invisibleGoalCount,
+      hasHoles: result.hasHoles,
+      isComplete: result.isComplete,
+    };
+  }
+  return classifyCompleteness({
+    success: result.success,
+    goals: new Array(result.goalCount),
+    invisibleGoalCount: result.invisibleGoalCount,
+  });
+}
+
 export function completenessFromLoadResult(
   result: LoadResult,
 ): CompletenessStatus {
-  return classifyCompleteness(result);
+  return completenessFromMerged(result);
 }
 
 export function completenessFromTypeCheckResult(
   result: TypeCheckResult,
 ): CompletenessStatus {
-  return classifyCompleteness(result);
+  return completenessFromMerged(result);
 }

--- a/src/agda/display-operations.ts
+++ b/src/agda/display-operations.ts
@@ -100,7 +100,11 @@ export async function showImplicitArgs(
 export async function toggleImplicitArgs(
   ctx: AgdaCommandContext,
 ): Promise<DisplayControlResult> {
-  return runControl(ctx, "ToggleImplicitArgs", "Toggled implicit arguments visibility.");
+  return runControl(
+    ctx,
+    command("ToggleImplicitArgs"),
+    "Toggled implicit arguments visibility.",
+  );
 }
 
 export async function showIrrelevantArgs(
@@ -119,7 +123,7 @@ export async function toggleIrrelevantArgs(
 ): Promise<DisplayControlResult> {
   return runControl(
     ctx,
-    "ToggleIrrelevantArgs",
+    command("ToggleIrrelevantArgs"),
     "Toggled irrelevant arguments visibility.",
   );
 }

--- a/src/agda/session.ts
+++ b/src/agda/session.ts
@@ -53,7 +53,7 @@ import {
   loadProjectConfig,
   mergeCommandLineOptions,
 } from "../session/project-config.js";
-import { iotcmEnvelope } from "../protocol/command-builder.js";
+import { iotcmEnvelope, topLevelCommand } from "../protocol/command-builder.js";
 import { statSync } from "node:fs";
 
 export { findAgdaBinary };
@@ -325,13 +325,13 @@ export class AgdaSession {
 
   /** Send Cmd_abort to the running Agda process. */
   async abort(): Promise<AgdaResponse[]> {
-    return this.runIndependentCommand("Cmd_abort", 10_000);
+    return this.runIndependentCommand(topLevelCommand("Cmd_abort"), 10_000);
   }
 
   /** Send Cmd_exit to the running Agda process. */
   async exit(): Promise<AgdaResponse[]> {
     this.exiting = true;
-    return this.runIndependentCommand("Cmd_exit", 10_000);
+    return this.runIndependentCommand(topLevelCommand("Cmd_exit"), 10_000);
   }
 
   // ── Accessors ─────────────────────────────────────────────────────

--- a/src/agda/session.ts
+++ b/src/agda/session.ts
@@ -53,6 +53,7 @@ import {
   loadProjectConfig,
   mergeCommandLineOptions,
 } from "../session/project-config.js";
+import { iotcmEnvelope } from "../protocol/command-builder.js";
 import { statSync } from "node:fs";
 
 export { findAgdaBinary };
@@ -214,8 +215,7 @@ export class AgdaSession {
    * Format: IOTCM "<filepath>" NonInteractive Direct (<agda-command>)
    */
   iotcm(agdaCmd: string): string {
-    const fp = this.currentFile ?? "";
-    return `IOTCM "${fp}" NonInteractive Direct (${agdaCmd})`;
+    return iotcmEnvelope(this.currentFile ?? "", agdaCmd);
   }
 
   /** Get the currently loaded file path, or throw if none loaded. */
@@ -233,10 +233,6 @@ export class AgdaSession {
     }
   }
 
-  private buildIotcm(filePath: string, agdaCmd: string): string {
-    return `IOTCM "${filePath}" NonInteractive Direct (${agdaCmd})`;
-  }
-
   /**
    * Build an IOTCM command string for a specific file path, bypassing
    * the session's currentFile. Used by the extracted load helpers
@@ -245,14 +241,14 @@ export class AgdaSession {
    * race with ensureProcess()'s stale-state reset path.
    */
   iotcmFor(filePath: string, agdaCmd: string): string {
-    return this.buildIotcm(filePath, agdaCmd);
+    return iotcmEnvelope(filePath, agdaCmd);
   }
 
   private async runIndependentCommand(
     agdaCmd: string,
     timeoutMs = 120_000,
   ): Promise<AgdaResponse[]> {
-    return this.sendCommand(this.buildIotcm(this.currentFile ?? "", agdaCmd), timeoutMs);
+    return this.sendCommand(iotcmEnvelope(this.currentFile ?? "", agdaCmd), timeoutMs);
   }
 
   // ── Public API ────────────────────────────────────────────────────

--- a/src/protocol/command-builder.ts
+++ b/src/protocol/command-builder.ts
@@ -88,3 +88,17 @@ export function rewriteGoalCommand(
 export function profileOptionsList(profileArgs: string[]): string {
   return stringList(profileArgs);
 }
+
+/**
+ * Wrap an inner Agda command in the IOTCM transport envelope.
+ *
+ * Format: `IOTCM "<filepath>" NonInteractive Direct (<inner-command>)`
+ *
+ * `filePath` is interpolated literally inside the surrounding quotes.
+ * Callers must already have validated/canonicalized the path —
+ * upstream sandboxing in `safe-source-io.ts` rules out the characters
+ * (`"`, raw newlines) that would otherwise corrupt this envelope.
+ */
+export function iotcmEnvelope(filePath: string, innerCommand: string): string {
+  return `IOTCM "${filePath}" NonInteractive Direct (${innerCommand})`;
+}

--- a/src/protocol/command-builder.ts
+++ b/src/protocol/command-builder.ts
@@ -94,11 +94,14 @@ export function profileOptionsList(profileArgs: string[]): string {
  *
  * Format: `IOTCM "<filepath>" NonInteractive Direct (<inner-command>)`
  *
- * `filePath` is interpolated literally inside the surrounding quotes.
- * Callers must already have validated/canonicalized the path —
- * upstream sandboxing in `safe-source-io.ts` rules out the characters
- * (`"`, raw newlines) that would otherwise corrupt this envelope.
+ * The file-path segment is escaped via `escapeAgdaString` (the same
+ * escaping `quoted` applies). POSIX permits `"` / `\` / `\n` in file
+ * paths, and project-root sandboxing (`resolveExistingPathWithinRoot`)
+ * does not strip those characters — so a path like `foo"bar.agda`
+ * would otherwise close the IOTCM envelope's opening quote and leak
+ * the rest of the path as literal protocol tokens. Escaping here
+ * keeps the envelope well-formed regardless of upstream path policy.
  */
 export function iotcmEnvelope(filePath: string, innerCommand: string): string {
-  return `IOTCM "${filePath}" NonInteractive Direct (${innerCommand})`;
+  return `IOTCM "${escapeAgdaString(filePath)}" NonInteractive Direct (${innerCommand})`;
 }

--- a/src/session/register-agda-apply-edit.ts
+++ b/src/session/register-agda-apply-edit.ts
@@ -88,6 +88,13 @@ export function registerAgdaApplyEdit(
         .optional()
         .describe("1-based occurrence number when oldText appears multiple times."),
     },
+    outputDataSchema: z.object({
+      text: z.string(),
+      file: z.string(),
+      applied: z.boolean(),
+      sandboxRejected: z.boolean(),
+      message: z.string(),
+    }),
     callback: async ({ file, oldText, newText, occurrence }) => {
       // Resolve AND canonicalize within the project root. Unlike the
       // lexical-only `resolveFileWithinRoot`, this helper runs
@@ -103,13 +110,31 @@ export function registerAgdaApplyEdit(
         canonicalPath = resolveExistingPathWithinRoot(repoRoot, file as string);
       } catch (err) {
         if (err instanceof PathSandboxError) {
-          return `## agda_apply_edit\n\n**Error:** ${err.message}\n`;
+          const text = `## agda_apply_edit\n\n**Error:** ${err.message}\n`;
+          return {
+            text,
+            data: {
+              file: file as string,
+              applied: false,
+              sandboxRejected: true,
+              message: err.message,
+            },
+          };
         }
         // realpath failure (ENOENT, permissions, etc.) — the file
         // either doesn't exist yet or is unreadable. Surface a
         // structured failure rather than throwing.
         const msg = err instanceof Error ? err.message : String(err);
-        return `## agda_apply_edit\n\n**Error:** Could not resolve file path: ${msg}\n`;
+        const text = `## agda_apply_edit\n\n**Error:** Could not resolve file path: ${msg}\n`;
+        return {
+          text,
+          data: {
+            file: file as string,
+            applied: false,
+            sandboxRejected: false,
+            message: `Could not resolve file path: ${msg}`,
+          },
+        };
       }
 
       // Extension allowlist: agda_apply_edit is meant for Agda
@@ -120,12 +145,20 @@ export function registerAgdaApplyEdit(
       // ".agda" suffix trick like `shell.sh/..%2f/foo.agda` from
       // bypassing the check.
       if (!hasAgdaSourceExtension(canonicalPath)) {
-        return (
-          `## agda_apply_edit\n\n` +
-          `**Error:** Refusing to edit \`${file}\`: agda_apply_edit is ` +
+        const message =
+          `Refusing to edit \`${file}\`: agda_apply_edit is ` +
           `restricted to Agda source files (${AGDA_SOURCE_EXTENSIONS.join(", ")}). ` +
-          `Use a general-purpose file-editing tool for non-Agda files.\n`
-        );
+          `Use a general-purpose file-editing tool for non-Agda files.`;
+        const text = `## agda_apply_edit\n\n**Error:** ${message}\n`;
+        return {
+          text,
+          data: {
+            file: file as string,
+            applied: false,
+            sandboxRejected: true,
+            message,
+          },
+        };
       }
 
       // Capture goal IDs before the edit so the reload can report a
@@ -154,7 +187,15 @@ export function registerAgdaApplyEdit(
 
       if (!editResult.applied) {
         output += `**Edit not applied:** ${editResult.message}\n`;
-        return output;
+        return {
+          text: output,
+          data: {
+            file: file as string,
+            applied: false,
+            sandboxRejected: false,
+            message: editResult.message,
+          },
+        };
       }
 
       output += `${editResult.message}\n`;
@@ -166,7 +207,15 @@ export function registerAgdaApplyEdit(
       // detection on subsequent calls.
       output += await reloadAndDiagnose(session, canonicalPath, "\n", goalIdsBefore);
 
-      return output;
+      return {
+        text: output,
+        data: {
+          file: file as string,
+          applied: true,
+          sandboxRejected: false,
+          message: editResult.message,
+        },
+      };
     },
   });
 }

--- a/src/tools/analysis-tools.ts
+++ b/src/tools/analysis-tools.ts
@@ -28,9 +28,31 @@ export function register(
     description: "Get a complete proof state snapshot: loaded file, staleness, all goals with types, and constraints. Use this instead of calling agda_session_status + agda_metas + agda_constraints separately.",
     category: "analysis",
     inputSchema: {},
+    outputDataSchema: z.object({
+      text: z.string(),
+      loadedFile: z.string().nullable(),
+      goalCount: z.number(),
+      hasConstraints: z.boolean(),
+      goals: z.array(z.object({
+        goalId: z.number(),
+        type: z.string(),
+      })),
+      constraintsText: z.string(),
+    }),
     callback: async () => {
       const file = session.getLoadedFile();
-      if (!file) return "No file loaded. Call `agda_load` first.";
+      if (!file) {
+        return {
+          text: "No file loaded. Call `agda_load` first.",
+          data: {
+            loadedFile: null,
+            goalCount: 0,
+            hasConstraints: false,
+            goals: [],
+            constraintsText: "",
+          },
+        };
+      }
 
       const metas = await session.goal.metas();
       const constraints = await session.query.constraints();
@@ -59,7 +81,16 @@ export function register(
         output += "All goals solved.\n";
       }
 
-      return output;
+      return {
+        text: output,
+        data: {
+          loadedFile: file,
+          goalCount: metas.goals.length,
+          hasConstraints: constraints.text.trim().length > 0,
+          goals: metas.goals.map((g) => ({ goalId: g.goalId, type: g.type })),
+          constraintsText: constraints.text,
+        },
+      };
     },
   });
 
@@ -74,6 +105,26 @@ export function register(
     inputSchema: {
       goalId: goalIdSchema.describe("The goal ID to analyze"),
     },
+    outputDataSchema: z.object({
+      text: z.string(),
+      goalId: goalIdSchema,
+      goalType: z.string(),
+      context: z.array(z.object({
+        name: z.string(),
+        type: z.string(),
+        isImplicit: z.boolean(),
+      })),
+      splittableVariables: z.array(z.object({
+        name: z.string(),
+        type: z.string(),
+      })),
+      suggestions: z.array(z.object({
+        action: z.string(),
+        expr: z.string().optional(),
+        variable: z.string().optional(),
+        reason: z.string(),
+      })),
+    }),
     callback: async ({ goalId }) => {
       const info = await session.goal.typeContext(goalId);
       const contextEntries = info.context.map(parseContextEntry);
@@ -108,7 +159,24 @@ export function register(
         output += `- ${desc} — ${s.reason}\n`;
       }
 
-      return output;
+      return {
+        text: output,
+        data: {
+          goalType: info.type ?? "",
+          context: contextEntries.map((e) => ({
+            name: e.name,
+            type: e.type,
+            isImplicit: e.isImplicit,
+          })),
+          splittableVariables: splittable.map((v) => ({ name: v.name, type: v.type })),
+          suggestions: suggestions.map((s) => ({
+            action: s.action,
+            expr: s.expr,
+            variable: s.variable,
+            reason: s.reason,
+          })),
+        },
+      };
     },
   });
 
@@ -120,9 +188,36 @@ export function register(
     description: "Reload the currently loaded file and report what changed: which goals were solved, which are new, and the current proof state.",
     category: "analysis",
     inputSchema: {},
+    outputDataSchema: z.object({
+      text: z.string(),
+      file: z.string().nullable(),
+      success: z.boolean(),
+      classification: z.string().nullable(),
+      wasStale: z.boolean(),
+      goalCount: z.number(),
+      solvedGoalIds: z.array(z.number()),
+      newGoalIds: z.array(z.number()),
+      unchangedGoalIds: z.array(z.number()),
+      errors: z.array(z.string()),
+    }),
     callback: async () => {
       const prevFile = session.getLoadedFile();
-      if (!prevFile) return "No file loaded. Call `agda_load` first.";
+      if (!prevFile) {
+        return {
+          text: "No file loaded. Call `agda_load` first.",
+          data: {
+            file: null,
+            success: false,
+            classification: null,
+            wasStale: false,
+            goalCount: 0,
+            solvedGoalIds: [],
+            newGoalIds: [],
+            unchangedGoalIds: [],
+            errors: [],
+          },
+        };
+      }
 
       const prevGoalIds = session.getGoalIds();
       const wasStale = session.isFileStale();
@@ -162,9 +257,36 @@ export function register(
 
         output += projectConfigWarningsText(result.projectConfigWarnings);
 
-        return output;
+        return {
+          text: output,
+          data: {
+            file: prevFile,
+            success: result.success,
+            classification: result.classification ?? null,
+            wasStale,
+            goalCount: newGoalIds.length,
+            solvedGoalIds: solved,
+            newGoalIds: created,
+            unchangedGoalIds: unchanged,
+            errors: result.errors,
+          },
+        };
       } catch (err) {
-        return `Error: ${err instanceof Error ? err.message : String(err)}`;
+        const message = `Error: ${err instanceof Error ? err.message : String(err)}`;
+        return {
+          text: message,
+          data: {
+            file: prevFile,
+            success: false,
+            classification: null,
+            wasStale,
+            goalCount: 0,
+            solvedGoalIds: [],
+            newGoalIds: [],
+            unchangedGoalIds: [],
+            errors: [message],
+          },
+        };
       }
     },
   });
@@ -184,6 +306,21 @@ export function register(
       offset: z.number().int().min(0).optional().describe("0-based pagination offset"),
       limit: z.number().int().min(1).max(200).optional().describe("Maximum results to return"),
     },
+    outputDataSchema: z.object({
+      text: z.string(),
+      goalId: goalIdSchema,
+      targetType: z.string(),
+      scope: z.enum(["local", "module", "imported"]),
+      totalCandidates: z.number(),
+      offset: z.number(),
+      limit: z.number(),
+      matches: z.array(z.object({
+        name: z.string(),
+        type: z.string(),
+        source: z.enum(["local", "module", "imported"]),
+      })),
+      hasMore: z.boolean(),
+    }),
     callback: async ({ goalId, targetType, scope, offset, limit }) => {
       const info = await session.goal.typeContext(goalId);
       const target = (targetType as string) || info.type;
@@ -258,7 +395,18 @@ export function register(
         output += `\n**Hint:** Goal is a function type. Consider \`refine\` or \`intro\` to introduce arguments.\n`;
       }
 
-      return output;
+      return {
+        text: output,
+        data: {
+          targetType: target,
+          scope: effectiveScope,
+          totalCandidates: merged.length,
+          offset: effectiveOffset,
+          limit: effectiveLimit,
+          matches,
+          hasMore: merged.length > effectiveOffset + effectiveLimit,
+        },
+      };
     },
   });
 }

--- a/src/tools/backend.ts
+++ b/src/tools/backend.ts
@@ -35,6 +35,13 @@ export function register(
       file: z.string().describe(filePathDescription(session.getAgdaVersion() ?? undefined)),
       args: z.array(z.string()).optional().describe("Optional Agda CLI arguments for the compile command"),
     },
+    outputDataSchema: z.object({
+      text: z.string(),
+      backend: z.string(),
+      file: z.string(),
+      success: z.boolean(),
+      output: z.string(),
+    }),
     callback: async ({ backend, file, args }: { backend: string; file: string; args?: string[] }) => {
       const requestedFilePath = resolveFileWithinRoot(repoRoot, file);
       if (!existsSync(requestedFilePath)) {
@@ -42,13 +49,23 @@ export function register(
       }
       const filePath = resolveExistingPathWithinRoot(repoRoot, requestedFilePath);
       const result = await session.backend.compile(backend, filePath, args);
-      return [
+      const relFile = relative(repoRoot, requestedFilePath);
+      const text = [
         "## Compile", "",
         `Backend: ${backend}`,
-        `File: ${relative(repoRoot, requestedFilePath)}`,
+        `File: ${relFile}`,
         `Status: ${result.success ? "OK" : "FAILED"}`, "",
         result.output || "(no output)",
       ].join("\n");
+      return {
+        text,
+        data: {
+          backend,
+          file: relFile,
+          success: result.success,
+          output: result.output ?? "",
+        },
+      };
     },
   });
 
@@ -62,14 +79,24 @@ export function register(
       backend: z.string().describe(backendExpressionHelp()),
       payload: z.string().describe("Arbitrary backend payload string"),
     },
+    outputDataSchema: z.object({
+      text: z.string(),
+      backend: z.string(),
+      success: z.boolean(),
+      output: z.string(),
+    }),
     callback: async ({ backend, payload }: { backend: string; payload: string }) => {
       const result = await session.backend.top(backend, payload);
-      return [
+      const text = [
         "## Backend top-level command", "",
         `Backend: ${backend}`,
         `Status: ${result.success ? "OK" : "FAILED"}`, "",
         result.output || "(no output)",
       ].join("\n");
+      return {
+        text,
+        data: { backend, success: result.success, output: result.output ?? "" },
+      };
     },
   });
 
@@ -86,6 +113,13 @@ export function register(
       backend: z.string().describe(backendExpressionHelp()),
       payload: z.string().describe("Arbitrary backend payload string"),
     },
+    outputDataSchema: z.object({
+      text: z.string(),
+      goalId: goalIdSchema,
+      backend: z.string(),
+      success: z.boolean(),
+      output: z.string(),
+    }),
     callback: async ({ goalId, holeContents, backend, payload }) => {
       const result = await session.backend.hole(
         goalId,
@@ -93,13 +127,21 @@ export function register(
         backend as string,
         payload as string,
       );
-      return [
+      const text = [
         "## Backend hole command", "",
         `Goal: ?${goalId}`,
         `Backend: ${backend}`,
         `Status: ${result.success ? "OK" : "FAILED"}`, "",
         result.output || "(no output)",
       ].join("\n");
+      return {
+        text,
+        data: {
+          backend: backend as string,
+          success: result.success,
+          output: result.output ?? "",
+        },
+      };
     },
   });
 }

--- a/src/tools/display.ts
+++ b/src/tools/display.ts
@@ -15,6 +15,17 @@ import {
 import { resolveExistingPathWithinRoot, resolveFileWithinRoot } from "../repo-root.js";
 import { goalIdSchema } from "./tool-schemas.js";
 
+/**
+ * Schema for the decoded display-state snapshot Agda returns on its
+ * status events. `null` distinguishes "Agda did not report this flag"
+ * from a known true/false. Reused by every display-control tool.
+ */
+const displayStateSchema = z.object({
+  showImplicitArguments: z.boolean().nullable(),
+  showIrrelevantArguments: z.boolean().nullable(),
+  checked: z.boolean().nullable(),
+});
+
 export function register(
   server: McpServer,
   session: AgdaSession,
@@ -27,6 +38,11 @@ export function register(
     category: "highlighting",
     protocolCommands: ["Cmd_load_highlighting_info"],
     inputSchema: { file: z.string().describe(filePathDescription(session.getAgdaVersion() ?? undefined)) },
+    outputDataSchema: z.object({
+      text: z.string(),
+      file: z.string(),
+      state: displayStateSchema,
+    }),
     callback: async ({ file }: { file: string }) => {
       const requestedFilePath = resolveFileWithinRoot(repoRoot, file);
       if (!existsSync(requestedFilePath)) {
@@ -34,7 +50,18 @@ export function register(
       }
       const filePath = resolveExistingPathWithinRoot(repoRoot, requestedFilePath);
       const result = await session.display.loadHighlightingInfo(filePath);
-      return `## Highlighting info loaded\n\nFile: ${relative(repoRoot, requestedFilePath)}\n\n${result.output}\n`;
+      const text = `## Highlighting info loaded\n\nFile: ${relative(repoRoot, requestedFilePath)}\n\n${result.output}\n`;
+      return {
+        text,
+        data: {
+          file: relative(repoRoot, requestedFilePath),
+          state: {
+            showImplicitArguments: result.showImplicitArguments,
+            showIrrelevantArguments: result.showIrrelevantArguments,
+            checked: result.checked,
+          },
+        },
+      };
     },
   });
 
@@ -47,6 +74,11 @@ export function register(
     inputSchema: {
       file: z.string().describe(filePathDescription(session.getAgdaVersion() ?? undefined)),
     },
+    outputDataSchema: z.object({
+      text: z.string(),
+      file: z.string(),
+      state: displayStateSchema,
+    }),
     callback: async ({ file }: { file: string }) => {
       const requestedFilePath = resolveFileWithinRoot(repoRoot, file);
       if (!existsSync(requestedFilePath)) {
@@ -54,7 +86,18 @@ export function register(
       }
       const filePath = resolveExistingPathWithinRoot(repoRoot, requestedFilePath);
       const result = await session.display.tokenHighlighting(filePath);
-      return `## Token highlighting\n\nFile: ${relative(repoRoot, requestedFilePath)}\n\n${result.output}\n`;
+      const text = `## Token highlighting\n\nFile: ${relative(repoRoot, requestedFilePath)}\n\n${result.output}\n`;
+      return {
+        text,
+        data: {
+          file: relative(repoRoot, requestedFilePath),
+          state: {
+            showImplicitArguments: result.showImplicitArguments,
+            showIrrelevantArguments: result.showIrrelevantArguments,
+            checked: result.checked,
+          },
+        },
+      };
     },
   });
 
@@ -69,9 +112,26 @@ export function register(
       goalId: goalIdSchema.describe("Goal ID used as highlighting context"),
       expr: z.string().describe("Expression to highlight"),
     },
+    outputDataSchema: z.object({
+      text: z.string(),
+      goalId: goalIdSchema,
+      expr: z.string(),
+      state: displayStateSchema,
+    }),
     callback: async ({ goalId, expr }) => {
       const result = await session.display.highlight(goalId, expr as string);
-      return `## Highlight\n\nGoal: ?${goalId}\nExpression: \`${expr}\`\n\n${result.output}\n`;
+      const text = `## Highlight\n\nGoal: ?${goalId}\nExpression: \`${expr}\`\n\n${result.output}\n`;
+      return {
+        text,
+        data: {
+          expr: expr as string,
+          state: {
+            showImplicitArguments: result.showImplicitArguments,
+            showIrrelevantArguments: result.showIrrelevantArguments,
+            checked: result.checked,
+          },
+        },
+      };
     },
   });
 
@@ -82,9 +142,25 @@ export function register(
     category: "process",
     protocolCommands: ["ShowImplicitArgs"],
     inputSchema: { enabled: z.boolean().describe("True to show implicit arguments, false to hide them") },
+    outputDataSchema: z.object({
+      text: z.string(),
+      requested: z.boolean(),
+      state: displayStateSchema,
+    }),
     callback: async ({ enabled }: { enabled: boolean }) => {
       const result = await session.display.showImplicitArgs(enabled);
-      return `## Show implicit arguments\n\nRequested: ${enabled}\n\n${result.output}\n`;
+      const text = `## Show implicit arguments\n\nRequested: ${enabled}\n\n${result.output}\n`;
+      return {
+        text,
+        data: {
+          requested: enabled,
+          state: {
+            showImplicitArguments: result.showImplicitArguments,
+            showIrrelevantArguments: result.showIrrelevantArguments,
+            checked: result.checked,
+          },
+        },
+      };
     },
   });
 
@@ -95,9 +171,23 @@ export function register(
     category: "process",
     protocolCommands: ["ToggleImplicitArgs"],
     inputSchema: {},
+    outputDataSchema: z.object({
+      text: z.string(),
+      state: displayStateSchema,
+    }),
     callback: async () => {
       const result = await session.display.toggleImplicitArgs();
-      return `## Toggle implicit arguments\n\n${result.output}\n`;
+      const text = `## Toggle implicit arguments\n\n${result.output}\n`;
+      return {
+        text,
+        data: {
+          state: {
+            showImplicitArguments: result.showImplicitArguments,
+            showIrrelevantArguments: result.showIrrelevantArguments,
+            checked: result.checked,
+          },
+        },
+      };
     },
   });
 
@@ -108,9 +198,25 @@ export function register(
     category: "process",
     protocolCommands: ["ShowIrrelevantArgs"],
     inputSchema: { enabled: z.boolean().describe("True to show irrelevant arguments, false to hide them") },
+    outputDataSchema: z.object({
+      text: z.string(),
+      requested: z.boolean(),
+      state: displayStateSchema,
+    }),
     callback: async ({ enabled }: { enabled: boolean }) => {
       const result = await session.display.showIrrelevantArgs(enabled);
-      return `## Show irrelevant arguments\n\nRequested: ${enabled}\n\n${result.output}\n`;
+      const text = `## Show irrelevant arguments\n\nRequested: ${enabled}\n\n${result.output}\n`;
+      return {
+        text,
+        data: {
+          requested: enabled,
+          state: {
+            showImplicitArguments: result.showImplicitArguments,
+            showIrrelevantArguments: result.showIrrelevantArguments,
+            checked: result.checked,
+          },
+        },
+      };
     },
   });
 
@@ -121,9 +227,23 @@ export function register(
     category: "process",
     protocolCommands: ["ToggleIrrelevantArgs"],
     inputSchema: {},
+    outputDataSchema: z.object({
+      text: z.string(),
+      state: displayStateSchema,
+    }),
     callback: async () => {
       const result = await session.display.toggleIrrelevantArgs();
-      return `## Toggle irrelevant arguments\n\n${result.output}\n`;
+      const text = `## Toggle irrelevant arguments\n\n${result.output}\n`;
+      return {
+        text,
+        data: {
+          state: {
+            showImplicitArguments: result.showImplicitArguments,
+            showIrrelevantArguments: result.showIrrelevantArguments,
+            checked: result.checked,
+          },
+        },
+      };
     },
   });
 }

--- a/src/tools/expression-tools.ts
+++ b/src/tools/expression-tools.ts
@@ -159,9 +159,19 @@ export function register(
       goalId: goalIdSchema.describe("The goal ID for context"),
       expr: z.string().describe("The Agda expression to elaborate"),
     },
+    outputDataSchema: z.object({
+      text: z.string(),
+      goalId: goalIdSchema,
+      expr: z.string(),
+      elaboration: z.string(),
+    }),
     callback: async ({ goalId, expr }) => {
       const result = await session.query.elaborate(goalId, expr as string);
-      return `## Elaborate \`${expr}\` in ?${goalId}\n\n\`\`\`agda\n${result.elaboration || "(no result)"}\n\`\`\`\n`;
+      const text = `## Elaborate \`${expr}\` in ?${goalId}\n\n\`\`\`agda\n${result.elaboration || "(no result)"}\n\`\`\`\n`;
+      return {
+        text,
+        data: { expr: expr as string, elaboration: result.elaboration ?? "" },
+      };
     },
   });
 
@@ -176,9 +186,19 @@ export function register(
       goalId: goalIdSchema.describe("The goal ID for context"),
       expr: z.string().describe("The expression to generate a helper for"),
     },
+    outputDataSchema: z.object({
+      text: z.string(),
+      goalId: goalIdSchema,
+      expr: z.string(),
+      helperType: z.string(),
+    }),
     callback: async ({ goalId, expr }) => {
       const result = await session.query.helperFunction(goalId, expr as string);
-      return `## Helper function for \`${expr}\` in ?${goalId}\n\n\`\`\`agda\n${result.helperType || "(no result)"}\n\`\`\`\n`;
+      const text = `## Helper function for \`${expr}\` in ?${goalId}\n\n\`\`\`agda\n${result.helperType || "(no result)"}\n\`\`\`\n`;
+      return {
+        text,
+        data: { expr: expr as string, helperType: result.helperType ?? "" },
+      };
     },
   });
 }

--- a/src/tools/file-tools.ts
+++ b/src/tools/file-tools.ts
@@ -54,6 +54,14 @@ export function register(
       file: z.string().describe(filePathDescription(session.getAgdaVersion() ?? undefined)),
       codeOnly: z.boolean().optional().describe("When true, extract only Agda code blocks from literate files, stripping prose. Has no effect on plain .agda files."),
     },
+    outputDataSchema: z.object({
+      text: z.string(),
+      file: z.string(),
+      lineCount: z.number(),
+      literateFormat: z.string().nullable(),
+      codeOnly: z.boolean(),
+      codeBlockCount: z.number().nullable(),
+    }),
     callback: async ({ file, codeOnly }: { file: string; codeOnly?: boolean }) => {
       const requestedFilePath = resolveFileWithinRoot(repoRoot, file);
       if (!existsSync(requestedFilePath)) {
@@ -63,8 +71,10 @@ export function register(
       const fileContent = readFileSync(filePath, "utf-8");
       const canonicalRoot = resolveExistingPathWithinRoot(repoRoot, ".");
       const relPath = relative(canonicalRoot, filePath);
+      const lineCount = fileContent.split("\n").length;
+      const isCodeOnly = Boolean(codeOnly);
 
-      if (codeOnly) {
+      if (isCodeOnly) {
         const extraction = extractLiterateCode(filePath, fileContent);
         if (extraction.format === null) {
           // Plain .agda — codeOnly has no effect, return as normal
@@ -72,11 +82,29 @@ export function register(
             .split("\n")
             .map((line, i) => `${String(i + 1).padStart(4)} | ${line}`)
             .join("\n");
-          return `## ${relPath}\n\n\`\`\`agda\n${numbered}\n\`\`\``;
+          return {
+            text: `## ${relPath}\n\n\`\`\`agda\n${numbered}\n\`\`\``,
+            data: {
+              file: relPath,
+              lineCount,
+              literateFormat: null,
+              codeOnly: true,
+              codeBlockCount: null,
+            },
+          };
         }
 
         if (extraction.blocks.length === 0) {
-          return `## ${relPath} (code only)\n\nNo Agda code blocks found in this ${extraction.format} literate file.`;
+          return {
+            text: `## ${relPath} (code only)\n\nNo Agda code blocks found in this ${extraction.format} literate file.`,
+            data: {
+              file: relPath,
+              lineCount,
+              literateFormat: extraction.format,
+              codeOnly: true,
+              codeBlockCount: 0,
+            },
+          };
         }
 
         let output = `## ${relPath} (code only — ${extraction.format} format, ${extraction.blocks.length} block(s))\n\n`;
@@ -87,14 +115,32 @@ export function register(
             .join("\n");
           output += `\`\`\`agda\n${numbered}\n\`\`\`\n\n`;
         }
-        return output.trimEnd();
+        return {
+          text: output.trimEnd(),
+          data: {
+            file: relPath,
+            lineCount,
+            literateFormat: extraction.format,
+            codeOnly: true,
+            codeBlockCount: extraction.blocks.length,
+          },
+        };
       }
 
       const numbered = fileContent
         .split("\n")
         .map((line, i) => `${String(i + 1).padStart(4)} | ${line}`)
         .join("\n");
-      return `## ${relPath}\n\n\`\`\`agda\n${numbered}\n\`\`\``;
+      return {
+        text: `## ${relPath}\n\n\`\`\`agda\n${numbered}\n\`\`\``,
+        data: {
+          file: relPath,
+          lineCount,
+          literateFormat: null,
+          codeOnly: false,
+          codeBlockCount: null,
+        },
+      };
     },
   });
 
@@ -111,6 +157,19 @@ export function register(
       ),
       pattern: z.string().optional().describe("Case-insensitive substring filter applied to each module's relative path before pagination."),
     },
+    outputDataSchema: z.object({
+      text: z.string(),
+      tier: z.string(),
+      pattern: z.string().nullable(),
+      total: z.number(),
+      filtered: z.number(),
+      offset: z.number(),
+      limit: z.number(),
+      modules: z.array(z.string()),
+      hasMore: z.boolean(),
+      nextOffset: z.number().nullable(),
+      unreadableSubtrees: z.array(z.string()),
+    }),
     callback: async ({ tier, offset, limit, pattern }: { tier: string; offset?: number; limit?: number; pattern?: string }) => {
       const requestedTierDir = resolveFileWithinRoot(repoRoot, join("agda", tier));
       if (!existsSync(requestedTierDir)) {
@@ -218,7 +277,21 @@ export function register(
         lines.push("");
         lines.push(`**Skipped ${unreadableDirs.length} unreadable subtree(s):** ${unreadableDirs.join(", ")}. Check file permissions or broken symlinks; modules beneath these directories are not included in the total count.`);
       }
-      return lines.join("\n");
+      return {
+        text: lines.join("\n"),
+        data: {
+          tier,
+          pattern: pattern ?? null,
+          total: modules.length,
+          filtered: filtered.length,
+          offset: effectiveOffset,
+          limit: effectiveLimit,
+          modules: page,
+          hasMore,
+          nextOffset: hasMore ? nextOffset : null,
+          unreadableSubtrees: unreadableDirs,
+        },
+      };
     },
   });
 
@@ -228,6 +301,18 @@ export function register(
     description: "Check an Agda file for postulate declarations. In Kernel/ files, postulates are forbidden by construction.",
     category: "navigation",
     inputSchema: { file: z.string().describe(filePathDescription(session.getAgdaVersion() ?? undefined)) },
+    outputDataSchema: z.object({
+      text: z.string(),
+      file: z.string(),
+      blockCount: z.number(),
+      declarationCount: z.number(),
+      isKernel: z.boolean(),
+      kernelViolation: z.boolean(),
+      blocks: z.array(z.object({
+        line: z.number(),
+        declarations: z.array(z.string()),
+      })),
+    }),
     callback: async ({ file }: { file: string }) => {
       const requestedFilePath = resolveFileWithinRoot(repoRoot, file);
       if (!existsSync(requestedFilePath)) {
@@ -297,10 +382,10 @@ export function register(
       const relPath = relative(canonicalRoot, filePath);
       const isKernel = relPath.startsWith("agda/Kernel/");
       let output = `## Postulate check: ${relPath}\n\n`;
+      const totalDecls = blocks.reduce((sum, b) => sum + b.declarations.length, 0);
       if (blocks.length === 0) {
         output += "No postulates found. Fully constructive.\n";
       } else {
-        const totalDecls = blocks.reduce((sum, b) => sum + b.declarations.length, 0);
         const declSummary = totalDecls > 0
           ? ` (${totalDecls} identifier${totalDecls === 1 ? "" : "s"} declared)`
           : "";
@@ -315,7 +400,20 @@ export function register(
           }
         }
       }
-      return output;
+      return {
+        text: output,
+        data: {
+          file: relPath,
+          blockCount: blocks.length,
+          declarationCount: totalDecls,
+          isKernel,
+          kernelViolation: isKernel && blocks.length > 0,
+          blocks: blocks.map((b) => ({
+            line: b.line,
+            declarations: b.declarations,
+          })),
+        },
+      };
     },
   });
 
@@ -329,6 +427,22 @@ export function register(
       typePattern: z.string().optional().describe("Type-shape query (wildcard `_` supported), e.g. `_ ≤ _ + _`"),
       tier: z.string().optional().describe("Optional tier to limit search (Kernel, Foundation, etc.)"),
     },
+    outputDataSchema: z.object({
+      text: z.string(),
+      mode: z.enum(["name", "type-pattern"]),
+      query: z.string(),
+      tier: z.string().nullable(),
+      matchCount: z.number(),
+      shown: z.number(),
+      truncated: z.boolean(),
+      matches: z.array(z.object({
+        file: z.string(),
+        line: z.number(),
+        text: z.string(),
+      })),
+      unreadableSubtrees: z.array(z.string()),
+      unreadableFiles: z.array(z.string()),
+    }),
     callback: async ({ query, typePattern, tier }: { query?: string; typePattern?: string; tier?: string }) => {
       const mode: "name" | "type-pattern" = typePattern ? "type-pattern" : "name";
       const actualQuery = (typePattern ?? query ?? "").trim();
@@ -440,12 +554,12 @@ export function register(
         relativeToRequestedRoot(repoRoot, requestedSearchRoot),
       );
       let output: string;
+      const capped = matches.slice(0, 50);
       if (matches.length === 0) {
         output = mode === "name"
           ? `No matches for "${actualQuery}" in ${tier ?? "agda/"}`
           : `No type-pattern matches for "${actualQuery}" in ${tier ?? "agda/"}`;
       } else {
-        const capped = matches.slice(0, 50);
         output = `## Search (${mode}): "${actualQuery}" (${matches.length} matches${matches.length > 50 ? ", showing first 50" : ""})\n\n`;
         for (const m of capped) output += `- **${m.file}:${m.line}** \`${m.text}\`\n`;
       }
@@ -459,7 +573,20 @@ export function register(
       if (truncatedAtCap) {
         output += `\n_Truncated at ${MAX_RAW_MATCHES} raw matches; refine the query to see the rest._`;
       }
-      return output;
+      return {
+        text: output,
+        data: {
+          mode,
+          query: actualQuery,
+          tier: tier ?? null,
+          matchCount: matches.length,
+          shown: capped.length,
+          truncated: truncatedAtCap,
+          matches: capped,
+          unreadableSubtrees: unreadableDirs,
+          unreadableFiles,
+        },
+      };
     },
   });
 }

--- a/src/tools/goal-tools.ts
+++ b/src/tools/goal-tools.ts
@@ -31,6 +31,12 @@ export function register(
     category: "proof",
     protocolCommands: ["Cmd_goal_type_context"],
     inputSchema: { goalId: goalIdSchema.describe("The goal ID (from agda_load output)") },
+    outputDataSchema: z.object({
+      text: z.string(),
+      goalId: goalIdSchema,
+      goalType: z.string(),
+      context: z.array(z.string()),
+    }),
     callback: async ({ goalId }) => {
       const info = await session.goal.typeContext(goalId);
       let output = `## Goal ?${goalId}\n\n`;
@@ -38,7 +44,10 @@ export function register(
         output += `### Context\n\`\`\`agda\n${info.context.join("\n")}\n\`\`\`\n\n`;
       }
       output += `### Goal type\n\`\`\`agda\n${info.type || "(unknown)"}\n\`\`\`\n`;
-      return output;
+      return {
+        text: output,
+        data: { goalType: info.type ?? "", context: info.context },
+      };
     },
   });
 
@@ -50,9 +59,15 @@ export function register(
     category: "proof",
     protocolCommands: ["Cmd_goal_type"],
     inputSchema: { goalId: goalIdSchema.describe("The goal ID (from agda_load output)") },
+    outputDataSchema: z.object({
+      text: z.string(),
+      goalId: goalIdSchema,
+      goalType: z.string(),
+    }),
     callback: async ({ goalId }) => {
       const info = await session.goal.type(goalId);
-      return `## Goal ?${goalId}\n\n### Goal type\n\`\`\`agda\n${info.type || "(unknown)"}\n\`\`\`\n`;
+      const text = `## Goal ?${goalId}\n\n### Goal type\n\`\`\`agda\n${info.type || "(unknown)"}\n\`\`\`\n`;
+      return { text, data: { goalType: info.type ?? "" } };
     },
   });
 
@@ -64,13 +79,18 @@ export function register(
     category: "proof",
     protocolCommands: ["Cmd_context"],
     inputSchema: { goalId: goalIdSchema.describe("The goal ID (from agda_load output)") },
+    outputDataSchema: z.object({
+      text: z.string(),
+      goalId: goalIdSchema,
+      context: z.array(z.string()),
+    }),
     callback: async ({ goalId }) => {
       const info = await session.goal.context(goalId);
       let output = `## Context for ?${goalId}\n\n`;
       output += info.context.length > 0
         ? `\`\`\`agda\n${info.context.join("\n")}\n\`\`\`\n`
         : "(empty context)\n";
-      return output;
+      return { text: output, data: { context: info.context } };
     },
   });
 
@@ -86,11 +106,19 @@ export function register(
       variable: z.string().describe("The variable name to case-split on"),
       writeToFile: z.boolean().optional().describe("Write changes to the file and reload (default: true)"),
     },
+    outputDataSchema: z.object({
+      text: z.string(),
+      goalId: goalIdSchema,
+      variable: z.string(),
+      clauses: z.array(z.string()),
+      written: z.boolean(),
+    }),
     callback: async ({ goalId, variable, writeToFile }) => {
       const shouldWrite = writeToFile !== false;
       const goalIdsBefore = session.getGoalIds();
       const result = await session.goal.caseSplit(goalId, variable as string);
       let output = `## Case split on \`${variable}\` in ?${goalId}\n\n`;
+      let written = false;
       if (result.clauses.length > 0) {
         output += `### New clauses\n\`\`\`agda\n${result.clauses.join("\n")}\n\`\`\`\n`;
 
@@ -98,13 +126,21 @@ export function register(
           output += await applyEditAndReload(session, goalIdsBefore, {
             kind: "replace-line", goalId, clauses: result.clauses,
           });
+          written = true;
         } else {
           output += `\nReplace the original clause with these, then call \`agda_load\` to reload.\n`;
         }
       } else {
         output += `No clauses generated. The variable may not be splittable.\n`;
       }
-      return output;
+      return {
+        text: output,
+        data: {
+          variable: variable as string,
+          clauses: result.clauses,
+          written,
+        },
+      };
     },
   });
 
@@ -120,6 +156,14 @@ export function register(
       expr: z.string().describe("The Agda expression to give"),
       writeToFile: z.boolean().optional().describe("Write changes to the file and reload (default: true)"),
     },
+    outputDataSchema: z.object({
+      text: z.string(),
+      goalId: goalIdSchema,
+      expr: z.string(),
+      result: z.string(),
+      replacementText: z.string().nullable(),
+      written: z.boolean(),
+    }),
     callback: async ({ goalId, expr, writeToFile }) => {
       const shouldWrite = writeToFile !== false;
       const exprStr = expr as string;
@@ -128,16 +172,26 @@ export function register(
       let output = `## Give \`${exprStr}\` to ?${goalId}\n\n`;
       output += result.result ? `**Result:** \`${result.result}\`\n` : `Expression accepted.\n`;
 
+      let written = false;
       if (shouldWrite && session.currentFile) {
         if (hasReplacementText(result.replacementText)) {
           output += await applyEditAndReload(session, goalIdsBefore, {
             kind: "replace-hole", goalId, expr: result.replacementText,
           });
+          written = true;
         } else {
           output += `\nAgda did not return a confirmed replacement. Apply the expression manually if appropriate, then call \`agda_load\`.\n`;
         }
       }
-      return output;
+      return {
+        text: output,
+        data: {
+          expr: exprStr,
+          result: result.result ?? "",
+          replacementText: result.replacementText ?? null,
+          written,
+        },
+      };
     },
   });
 
@@ -153,6 +207,14 @@ export function register(
       expr: z.string().describe("The expression to refine with (can be empty to let Agda choose)"),
       writeToFile: z.boolean().optional().describe("Write changes to the file and reload (default: true)"),
     },
+    outputDataSchema: z.object({
+      text: z.string(),
+      goalId: goalIdSchema,
+      expr: z.string(),
+      result: z.string(),
+      replacementText: z.string().nullable(),
+      written: z.boolean(),
+    }),
     callback: async ({ goalId, expr, writeToFile }) => {
       const shouldWrite = writeToFile !== false;
       const exprStr = expr as string;
@@ -163,16 +225,26 @@ export function register(
         ? `**Result:** \`${result.result}\`\n`
         : `Refinement applied. Call \`agda_metas\` to see new goals.\n`;
 
+      let written = false;
       if (shouldWrite && session.currentFile) {
         if (hasReplacementText(result.replacementText)) {
           output += await applyEditAndReload(session, goalIdsBefore, {
             kind: "replace-hole", goalId, expr: result.replacementText,
           });
+          written = true;
         } else {
           output += `\nNo concrete replacement text was returned, so the file was not modified.\n`;
         }
       }
-      return output;
+      return {
+        text: output,
+        data: {
+          expr: exprStr,
+          result: result.result ?? "",
+          replacementText: result.replacementText ?? null,
+          written,
+        },
+      };
     },
   });
 
@@ -188,6 +260,14 @@ export function register(
       expr: z.string().describe("The expression to refine with"),
       writeToFile: z.boolean().optional().describe("Write changes to the file and reload (default: true)"),
     },
+    outputDataSchema: z.object({
+      text: z.string(),
+      goalId: goalIdSchema,
+      expr: z.string(),
+      result: z.string(),
+      replacementText: z.string().nullable(),
+      written: z.boolean(),
+    }),
     callback: async ({ goalId, expr, writeToFile }) => {
       const shouldWrite = writeToFile !== false;
       const exprStr = expr as string;
@@ -198,16 +278,26 @@ export function register(
         ? `**Result:** \`${result.result}\`\n`
         : "Refinement applied. Call `agda_metas` to inspect resulting goals.\n";
 
+      let written = false;
       if (shouldWrite && session.currentFile) {
         if (hasReplacementText(result.replacementText)) {
           output += await applyEditAndReload(session, goalIdsBefore, {
             kind: "replace-hole", goalId, expr: result.replacementText,
           });
+          written = true;
         } else {
           output += `\nNo confirmed replacement text was returned by Agda, so the file was left unchanged. Apply the refinement manually if needed.\n`;
         }
       }
-      return output;
+      return {
+        text: output,
+        data: {
+          expr: exprStr,
+          result: result.result ?? "",
+          replacementText: result.replacementText ?? null,
+          written,
+        },
+      };
     },
   });
 
@@ -223,6 +313,13 @@ export function register(
       expr: z.string().optional().describe("Optional existing goal contents to use as input"),
       writeToFile: z.boolean().optional().describe("Write changes to the file and reload (default: true)"),
     },
+    outputDataSchema: z.object({
+      text: z.string(),
+      goalId: goalIdSchema,
+      result: z.string(),
+      replacementText: z.string().nullable(),
+      written: z.boolean(),
+    }),
     callback: async ({ goalId, expr, writeToFile }) => {
       const shouldWrite = writeToFile !== false;
       const exprStr = (expr as string | undefined) ?? "";
@@ -233,16 +330,25 @@ export function register(
         ? `**Result:** \`${result.result}\`\n`
         : "Introduction applied. Call `agda_metas` to inspect resulting goals.\n";
 
+      let written = false;
       if (shouldWrite && session.currentFile) {
         if (hasReplacementText(result.replacementText)) {
           output += await applyEditAndReload(session, goalIdsBefore, {
             kind: "replace-hole", goalId, expr: result.replacementText,
           });
+          written = true;
         } else {
           output += `\nAgda did not return a confirmed replacement, so the file was left unchanged.\n`;
         }
       }
-      return output;
+      return {
+        text: output,
+        data: {
+          result: result.result ?? "",
+          replacementText: result.replacementText ?? null,
+          written,
+        },
+      };
     },
   });
 
@@ -261,6 +367,14 @@ export function register(
       hints: z.array(z.string()).optional().describe("Hints/modules to prioritize during search"),
       writeToFile: z.boolean().optional().describe("Write changes to the file and reload (default: true)"),
     },
+    outputDataSchema: z.object({
+      text: z.string(),
+      goalId: goalIdSchema,
+      solution: z.string(),
+      hasSolution: z.boolean(),
+      searchPayload: z.string(),
+      written: z.boolean(),
+    }),
     callback: async ({ goalId, writeToFile, depth, listCandidates, excludeHints, hints }) => {
       const shouldWrite = writeToFile !== false;
       const goalIdsBefore = session.getGoalIds();
@@ -277,16 +391,26 @@ export function register(
         output += `\nSearch payload: \`${payload}\`\n`;
       }
 
+      let written = false;
       if (shouldWrite && session.currentFile) {
         if (hasReplacementText(result.solution)) {
           output += await applyEditAndReload(session, goalIdsBefore, {
             kind: "replace-hole", goalId, expr: result.solution,
           });
+          written = true;
         } else {
           output += `\nAuto returned no solution, so the file was left unchanged.\n`;
         }
       }
-      return output;
+      return {
+        text: output,
+        data: {
+          solution: result.solution ?? "",
+          hasSolution: Boolean(result.solution),
+          searchPayload: payload,
+          written,
+        },
+      };
     },
   });
 
@@ -301,6 +425,14 @@ export function register(
       goalId: goalIdSchema.describe("The goal ID for context"),
       expr: z.string().describe("The Agda expression to check against the goal type"),
     },
+    outputDataSchema: z.object({
+      text: z.string(),
+      goalId: goalIdSchema,
+      expr: z.string(),
+      goalType: z.string(),
+      context: z.array(z.string()),
+      checkedExpr: z.string(),
+    }),
     callback: async ({ goalId, expr }) => {
       const result = await session.goal.typeContextCheck(goalId, expr as string);
       let output = `## Goal ?${goalId}, context, and checked term\n\n`;
@@ -309,7 +441,15 @@ export function register(
       }
       output += `### Goal type\n\n\`\`\`agda\n${result.goalType || "(unknown)"}\n\`\`\`\n\n`;
       output += `### Checked term for \`${expr}\`\n\n\`\`\`agda\n${result.checkedExpr || "(no checked term returned)"}\n\`\`\`\n`;
-      return output;
+      return {
+        text: output,
+        data: {
+          expr: expr as string,
+          goalType: result.goalType ?? "",
+          context: result.context,
+          checkedExpr: result.checkedExpr ?? "",
+        },
+      };
     },
   });
 
@@ -324,6 +464,14 @@ export function register(
       goalId: goalIdSchema.describe("The goal ID for context"),
       expr: z.string().describe("The Agda expression to infer in context"),
     },
+    outputDataSchema: z.object({
+      text: z.string(),
+      goalId: goalIdSchema,
+      expr: z.string(),
+      goalType: z.string(),
+      context: z.array(z.string()),
+      inferredType: z.string(),
+    }),
     callback: async ({ goalId, expr }) => {
       const result = await session.query.goalTypeContextInfer(goalId, expr as string);
       let output = `## Goal ?${goalId}, context, and inferred type\n\n`;
@@ -332,7 +480,15 @@ export function register(
       }
       output += `### Goal type\n\n\`\`\`agda\n${result.goalType || "(unknown)"}\n\`\`\`\n\n`;
       output += `### Inferred type for \`${expr}\`\n\n\`\`\`agda\n${result.inferredType || "(unable to infer)"}\n\`\`\`\n`;
-      return output;
+      return {
+        text: output,
+        data: {
+          expr: expr as string,
+          goalType: result.goalType ?? "",
+          context: result.context,
+          inferredType: result.inferredType ?? "",
+        },
+      };
     },
   });
 }

--- a/src/tools/query-tools.ts
+++ b/src/tools/query-tools.ts
@@ -176,13 +176,23 @@ export function register(
     category: "proof",
     protocolCommands: ["Cmd_autoAll"],
     inputSchema: {},
+    outputDataSchema: z.object({
+      text: z.string(),
+      solution: z.string(),
+      hasSolution: z.boolean(),
+    }),
     callback: async () => {
       const result = await session.query.autoAll();
-      let output = `## Auto-solve all goals\n\n`;
-      output += result.solution
-        ? `**Result:**\n\`\`\`\n${result.solution}\n\`\`\`\n`
-        : `No automatic solutions found.\n`;
-      return output;
+      const text = result.solution
+        ? `## Auto-solve all goals\n\n**Result:**\n\`\`\`\n${result.solution}\n\`\`\`\n`
+        : `## Auto-solve all goals\n\nNo automatic solutions found.\n`;
+      return {
+        text,
+        data: {
+          solution: result.solution ?? "",
+          hasSolution: Boolean(result.solution),
+        },
+      };
     },
   });
 
@@ -196,27 +206,43 @@ export function register(
     inputSchema: {
       writeToFile: z.boolean().optional().describe("Write solutions to the source file and reload (default: true)"),
     },
+    outputDataSchema: z.object({
+      text: z.string(),
+      solutionCount: z.number(),
+      solutions: z.array(z.string()),
+      rawSolutions: z.array(z.object({ goalId: z.number(), expr: z.string() })),
+      written: z.boolean(),
+    }),
     callback: async ({ writeToFile }) => {
       const shouldWrite = writeToFile !== false;
       const goalIdsBefore = session.getGoalIds();
       const result = await session.query.solveAll();
       let output = `## Solve all\n\n`;
+      let written = false;
 
       if (result.solutions.length === 0) {
         output += `No goals with unique solutions found.\n`;
-        return output;
+      } else {
+        output += `**Solutions:**\n`;
+        for (const s of result.solutions) output += `- ${s}\n`;
+
+        if (shouldWrite && session.currentFile && result.rawSolutions.length > 0) {
+          output += await applyBatchEditAndReload(
+            session, goalIdsBefore, session.currentFile, result.rawSolutions,
+          );
+          written = true;
+        }
       }
 
-      output += `**Solutions:**\n`;
-      for (const s of result.solutions) output += `- ${s}\n`;
-
-      if (shouldWrite && session.currentFile && result.rawSolutions.length > 0) {
-        output += await applyBatchEditAndReload(
-          session, goalIdsBefore, session.currentFile, result.rawSolutions,
-        );
-      }
-
-      return output;
+      return {
+        text: output,
+        data: {
+          solutionCount: result.solutions.length,
+          solutions: result.solutions,
+          rawSolutions: result.rawSolutions,
+          written,
+        },
+      };
     },
   });
 
@@ -231,26 +257,43 @@ export function register(
       goalId: goalIdSchema.describe("The goal ID to solve if it has a unique solution"),
       writeToFile: z.boolean().optional().describe("Write the solution to the source file and reload (default: true)"),
     },
+    outputDataSchema: z.object({
+      text: z.string(),
+      goalId: goalIdSchema,
+      solutionCount: z.number(),
+      solutions: z.array(z.string()),
+      rawSolutions: z.array(z.object({ goalId: z.number(), expr: z.string() })),
+      written: z.boolean(),
+    }),
     callback: async ({ goalId, writeToFile }) => {
       const shouldWrite = writeToFile !== false;
       const goalIdsBefore = session.getGoalIds();
       const result = await session.query.solveOne(goalId);
       let output = `## Solve one ?${goalId}\n\n`;
+      let written = false;
 
       if (result.solutions.length === 0) {
         output += "No unique solution found for that goal.\n";
-        return output;
+      } else {
+        for (const solution of result.solutions) output += `- ${solution}\n`;
+
+        if (shouldWrite && session.currentFile && result.rawSolutions.length > 0) {
+          output += await applyBatchEditAndReload(
+            session, goalIdsBefore, session.currentFile, result.rawSolutions,
+          );
+          written = true;
+        }
       }
 
-      for (const solution of result.solutions) output += `- ${solution}\n`;
-
-      if (shouldWrite && session.currentFile && result.rawSolutions.length > 0) {
-        output += await applyBatchEditAndReload(
-          session, goalIdsBefore, session.currentFile, result.rawSolutions,
-        );
-      }
-
-      return output;
+      return {
+        text: output,
+        data: {
+          solutionCount: result.solutions.length,
+          solutions: result.solutions,
+          rawSolutions: result.rawSolutions,
+          written,
+        },
+      };
     },
   });
 
@@ -262,11 +305,23 @@ export function register(
     category: "proof",
     protocolCommands: ["Cmd_constraints"],
     inputSchema: {},
+    outputDataSchema: z.object({
+      text: z.string(),
+      raw: z.string(),
+      hasConstraints: z.boolean(),
+    }),
     callback: async () => {
       const result = await session.query.constraints();
-      let output = `## Constraints\n\n`;
-      output += result.text ? `\`\`\`\n${result.text}\n\`\`\`\n` : `No constraints.\n`;
-      return output;
+      const output = result.text
+        ? `## Constraints\n\n\`\`\`\n${result.text}\n\`\`\`\n`
+        : `## Constraints\n\nNo constraints.\n`;
+      return {
+        text: output,
+        data: {
+          raw: result.text,
+          hasConstraints: result.text.trim().length > 0,
+        },
+      };
     },
   });
 }

--- a/src/tools/tool-registration.ts
+++ b/src/tools/tool-registration.ts
@@ -269,17 +269,37 @@ export function registerTextTool(args: {
 }
 
 /**
+ * Reserved envelope-data keys the wrapper controls. A tool callback
+ * cannot override them via its `data` payload — letting it would let
+ * `data.text` desync from the markdown body, or let `data.goalId`
+ * disagree with the validated `cbArgs.goalId`.
+ */
+const RESERVED_TEXT_DATA_KEYS = new Set(["text"]);
+const RESERVED_GOAL_TEXT_DATA_KEYS = new Set(["text", "goalId"]);
+
+/**
  * Normalize a `registerTextTool` / `registerGoalTextTool` callback
  * return value to the `{ text, extra }` shape the envelope builder
  * expects. Accepts the legacy bare-string form for backward compat.
+ *
+ * `reserved` names any keys the wrapper itself owns (`text`, plus
+ * `goalId` for goal tools); they are stripped from `extra` so a
+ * callback's `data` payload cannot clobber them on merge.
  */
 function unpackTextCallbackResult(
   raw: string | { text: string; data?: Record<string, unknown> },
+  reserved: Set<string> = RESERVED_TEXT_DATA_KEYS,
 ): { text: string; extra: Record<string, unknown> } {
   if (typeof raw === "string") {
     return { text: raw, extra: {} };
   }
-  return { text: raw.text, extra: raw.data ?? {} };
+  const data = raw.data ?? {};
+  const extra: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(data)) {
+    if (reserved.has(key)) continue;
+    extra[key] = value;
+  }
+  return { text: raw.text, extra };
 }
 
 /**
@@ -341,7 +361,10 @@ export function registerGoalTextTool<A extends Record<string, unknown>>(args: {
       try {
         const warn = stalenessWarning(args.session);
         const raw = await args.callback(cbArgs);
-        const { text: body, extra } = unpackTextCallbackResult(raw);
+        const { text: body, extra } = unpackTextCallbackResult(
+          raw,
+          RESERVED_GOAL_TEXT_DATA_KEYS,
+        );
         const textValue = warn + body;
         return makeToolResult(
           okEnvelope({

--- a/src/tools/tool-registration.ts
+++ b/src/tools/tool-registration.ts
@@ -215,7 +215,16 @@ export function registerTextTool(args: {
    * behavior is unchanged from the pre-#39 release.
    */
   session?: AgdaSession;
-  callback: (cbArgs: any) => Promise<string>;
+  /**
+   * Either return a text body (legacy path) or a structured payload
+   * with the same text rendering plus extra fields. Tools that have
+   * machine-decoded data — solve solutions, display state, postulate
+   * lists — should return the structured form so the envelope's
+   * `data` carries the parsed result alongside the prose body.
+   * Issue #11 scope: "expand richer per-tool data beyond plain text
+   * where still missing".
+   */
+  callback: (cbArgs: any) => Promise<string | { text: string; data?: Record<string, unknown> }>;
 }): void {
   const outputDataSchema =
     args.outputDataSchema ?? z.object({ text: z.string() });
@@ -236,7 +245,8 @@ export function registerTextTool(args: {
         if (unavailable) return unavailable;
       }
       try {
-        const textValue = await args.callback(cbArgs);
+        const raw = await args.callback(cbArgs);
+        const { text: textValue, extra } = unpackTextCallbackResult(raw);
         return makeToolResult(
           okEnvelope({
             tool: args.name,
@@ -246,7 +256,7 @@ export function registerTextTool(args: {
             // body still goes in `data.text` and the markdown body
             // alongside.
             summary: digestText(textValue),
-            data: { text: textValue },
+            data: { text: textValue, ...extra },
             elapsedMs: Math.round(performance.now() - startMs),
           }),
           textValue,
@@ -256,6 +266,20 @@ export function registerTextTool(args: {
       }
     },
   });
+}
+
+/**
+ * Normalize a `registerTextTool` / `registerGoalTextTool` callback
+ * return value to the `{ text, extra }` shape the envelope builder
+ * expects. Accepts the legacy bare-string form for backward compat.
+ */
+function unpackTextCallbackResult(
+  raw: string | { text: string; data?: Record<string, unknown> },
+): { text: string; extra: Record<string, unknown> } {
+  if (typeof raw === "string") {
+    return { text: raw, extra: {} };
+  }
+  return { text: raw.text, extra: raw.data ?? {} };
 }
 
 /**
@@ -280,7 +304,7 @@ export function registerGoalTextTool<A extends Record<string, unknown>>(args: {
   inputSchema: unknown;
   annotations?: ToolAnnotations;
   outputDataSchema?: z.ZodTypeAny;
-  callback: (cbArgs: A & { goalId: number }) => Promise<string>;
+  callback: (cbArgs: A & { goalId: number }) => Promise<string | { text: string; data?: Record<string, unknown> }>;
 }): void {
   const outputDataSchema =
     args.outputDataSchema
@@ -316,7 +340,8 @@ export function registerGoalTextTool<A extends Record<string, unknown>>(args: {
 
       try {
         const warn = stalenessWarning(args.session);
-        const body = await args.callback(cbArgs);
+        const raw = await args.callback(cbArgs);
+        const { text: body, extra } = unpackTextCallbackResult(raw);
         const textValue = warn + body;
         return makeToolResult(
           okEnvelope({
@@ -324,7 +349,7 @@ export function registerGoalTextTool<A extends Record<string, unknown>>(args: {
             // 1-line digest of the goal-text body (multi-line bodies
             // would otherwise be repeated whole in `summary`).
             summary: digestText(body),
-            data: { text: body, goalId: cbArgs.goalId },
+            data: { text: body, goalId: cbArgs.goalId, ...extra },
             stale: args.session.isFileStale() || undefined,
             elapsedMs: Math.round(performance.now() - startMs),
           }),

--- a/test/property/protocol/command-builder.property.test.ts
+++ b/test/property/protocol/command-builder.property.test.ts
@@ -115,8 +115,10 @@ test("modeGoalCommand and rewriteGoalCommand keep goalId before noRange", async 
 test("iotcmEnvelope wraps any inner command without altering its body", async () => {
   await fc.assert(
     fc.property(
-      // Path generator: avoid `"` and newlines so the envelope shape is well-defined.
-      fc.string({ maxLength: 80 }).filter((path) => !path.includes('"') && !path.includes("\n")),
+      // Cover arbitrary file paths including ones with `"`, `\`, and `\n`
+      // — the escape inside iotcmEnvelope must keep the envelope shape
+      // well-formed for any string the OS could legitimately produce.
+      fc.string({ maxLength: 80 }),
       fc.constantFrom(
         topLevelCommand("Cmd_show_version"),
         topLevelCommand("Cmd_abort"),
@@ -125,14 +127,18 @@ test("iotcmEnvelope wraps any inner command without altering its body", async ()
       ),
       (path, inner) => {
         const envelope = iotcmEnvelope(path, inner);
-        expect(envelope.startsWith(`IOTCM "${path}" NonInteractive Direct (`)).toBeTruthy();
+        // Reconstruct the expected escaped path the same way `quoted`
+        // does so an embedded `"` can't trick us into a vacuous match.
+        const escapedPath = quoted(path);
+        const prefix = `IOTCM ${escapedPath} NonInteractive Direct (`;
+        expect(envelope.startsWith(prefix)).toBeTruthy();
         expect(envelope.endsWith(")")).toBeTruthy();
         // The inner command must appear verbatim inside the parentheses.
-        const innerRendered = envelope.slice(
-          `IOTCM "${path}" NonInteractive Direct (`.length,
-          -1,
-        );
+        const innerRendered = envelope.slice(prefix.length, -1);
         expect(innerRendered).toBe(inner);
+        // The envelope must contain no raw newlines — they would
+        // otherwise corrupt the line-delimited stdin transport.
+        expect(envelope.includes("\n")).toBeFalsy();
       },
     ),
   );

--- a/test/property/protocol/command-builder.property.test.ts
+++ b/test/property/protocol/command-builder.property.test.ts
@@ -1,0 +1,139 @@
+// MIT License — see LICENSE
+//
+// Property-based invariants for the typed IOTCM command builder.
+//
+// These cover the structural guarantees that issue #10 asks for:
+//   - escaping invariants for `quoted` (no raw newlines, all `"` escaped)
+//   - shape invariants for goal-scoped builders (`noRange` placement)
+//   - stability of `iotcmEnvelope` wrapping arbitrary inner commands
+
+import { test, expect } from "vitest";
+
+import { fc } from "@fast-check/vitest";
+
+import {
+  boolLiteral,
+  command,
+  goalCommand,
+  iotcmEnvelope,
+  modeGoalCommand,
+  rewriteGoalCommand,
+  quoted,
+  stringList,
+  topLevelCommand,
+} from "../../../src/protocol/command-builder.js";
+
+test("quoted strips raw newlines and escapes every embedded quote", async () => {
+  await fc.assert(
+    fc.property(fc.string(), (raw) => {
+      const rendered = quoted(raw);
+      expect(rendered.startsWith('"')).toBeTruthy();
+      expect(rendered.endsWith('"')).toBeTruthy();
+
+      const inner = rendered.slice(1, -1);
+      expect(!inner.includes("\n")).toBeTruthy();
+
+      // Every `"` in the inner payload must be preceded by a backslash —
+      // otherwise the IOTCM envelope would close prematurely.
+      for (let index = 0; index < inner.length; index += 1) {
+        if (inner[index] === '"') {
+          expect(index > 0 && inner[index - 1] === "\\").toBeTruthy();
+        }
+      }
+    }),
+  );
+});
+
+test("stringList renders [] for empty and quoted entries otherwise", async () => {
+  await fc.assert(
+    fc.property(fc.array(fc.string(), { maxLength: 6 }), (values) => {
+      const rendered = stringList(values);
+      if (values.length === 0) {
+        expect(rendered).toBe("[]");
+        return;
+      }
+      expect(rendered.startsWith("[")).toBeTruthy();
+      expect(rendered.endsWith("]")).toBeTruthy();
+      // Every entry round-trips through `quoted` and is comma-joined.
+      const expected = `[${values.map(quoted).join(", ")}]`;
+      expect(rendered).toBe(expected);
+    }),
+  );
+});
+
+test("boolLiteral always renders True or False", async () => {
+  await fc.assert(
+    fc.property(fc.boolean(), (value) => {
+      const rendered = boolLiteral(value);
+      expect(rendered === "True" || rendered === "False").toBeTruthy();
+    }),
+  );
+});
+
+test("goalCommand places the integer goal id followed by noRange", async () => {
+  await fc.assert(
+    fc.property(
+      fc.string({ minLength: 1, maxLength: 32 }).filter((s) => /^[A-Za-z_][A-Za-z0-9_]*$/u.test(s)),
+      fc.integer({ min: 0, max: 1_000_000 }),
+      (name, goalId) => {
+        const rendered = goalCommand(name, goalId);
+        const parts = rendered.split(" ");
+        expect(parts[0]).toBe(name);
+        expect(parts[1]).toBe(String(goalId));
+        expect(parts[2]).toBe("noRange");
+      },
+    ),
+  );
+});
+
+test("modeGoalCommand and rewriteGoalCommand keep goalId before noRange", async () => {
+  await fc.assert(
+    fc.property(
+      fc.constantFrom("Cmd_infer", "Cmd_compute", "Cmd_goal_type", "Cmd_autoOne"),
+      fc.constantFrom("Normalised", "Simplified", "Instantiated", "DefaultCompute"),
+      fc.integer({ min: 0, max: 4096 }),
+      (name, mode, goalId) => {
+        const modeRendered = modeGoalCommand(name, mode, goalId);
+        const modeParts = modeRendered.split(" ");
+        expect(modeParts[0]).toBe(name);
+        expect(modeParts[1]).toBe(mode);
+        expect(modeParts[2]).toBe(String(goalId));
+        expect(modeParts[3]).toBe("noRange");
+
+        const rewriteRendered = rewriteGoalCommand(name, mode, goalId);
+        // rewriteGoalCommand uses the same shape — `(name, rewrite, goalId, noRange, ...)`.
+        const rewriteParts = rewriteRendered.split(" ");
+        expect(rewriteParts[0]).toBe(name);
+        expect(rewriteParts[1]).toBe(mode);
+        expect(rewriteParts[2]).toBe(String(goalId));
+        expect(rewriteParts[3]).toBe("noRange");
+      },
+    ),
+  );
+});
+
+test("iotcmEnvelope wraps any inner command without altering its body", async () => {
+  await fc.assert(
+    fc.property(
+      // Path generator: avoid `"` and newlines so the envelope shape is well-defined.
+      fc.string({ maxLength: 80 }).filter((path) => !path.includes('"') && !path.includes("\n")),
+      fc.constantFrom(
+        topLevelCommand("Cmd_show_version"),
+        topLevelCommand("Cmd_abort"),
+        command("Cmd_load", quoted("/x/y.agda"), "[]"),
+        goalCommand("Cmd_make_case", 3, quoted("xs")),
+      ),
+      (path, inner) => {
+        const envelope = iotcmEnvelope(path, inner);
+        expect(envelope.startsWith(`IOTCM "${path}" NonInteractive Direct (`)).toBeTruthy();
+        expect(envelope.endsWith(")")).toBeTruthy();
+        // The inner command must appear verbatim inside the parentheses.
+        const innerRendered = envelope.slice(
+          `IOTCM "${path}" NonInteractive Direct (`.length,
+          -1,
+        );
+        expect(innerRendered).toBe(inner);
+      },
+    ),
+  );
+});

--- a/test/unit/protocol/command-builder.test.ts
+++ b/test/unit/protocol/command-builder.test.ts
@@ -4,6 +4,7 @@ import {
   boolLiteral,
   command,
   goalCommand,
+  iotcmEnvelope,
   modeGoalCommand,
   modeTopLevelCommand,
   profileOptionsList,
@@ -11,6 +12,7 @@ import {
   rewriteGoalCommand,
   rewriteTopLevelCommand,
   stringList,
+  topLevelCommand,
 } from "../../../src/protocol/command-builder.js";
 
 test("quoted escapes raw newlines and quotes", () => {
@@ -70,4 +72,26 @@ test("Cmd_load with profile options produces correct IOTCM payload", () => {
 test("Cmd_load without profile options uses empty list", () => {
   const cmd = command("Cmd_load", quoted("/path/to/file.agda"), "[]");
   expect(cmd).toBe('Cmd_load "/path/to/file.agda" []');
+});
+
+test("iotcmEnvelope wraps inner command for the configured file", () => {
+  const inner = topLevelCommand("Cmd_show_version");
+  expect(iotcmEnvelope("/abs/path/M.agda", inner)).toBe(
+    'IOTCM "/abs/path/M.agda" NonInteractive Direct (Cmd_show_version)',
+  );
+});
+
+test("iotcmEnvelope tolerates an empty file path for pre-load commands", () => {
+  // session.ts uses an empty file path before any Cmd_load has bound a
+  // currentFile (e.g. version detection). The envelope shape must remain
+  // syntactically valid.
+  const inner = topLevelCommand("Cmd_show_version");
+  expect(iotcmEnvelope("", inner)).toBe(
+    'IOTCM "" NonInteractive Direct (Cmd_show_version)',
+  );
+});
+
+test("topLevelCommand with no parts produces the bare command name", () => {
+  expect(topLevelCommand("Cmd_show_version")).toBe("Cmd_show_version");
+  expect(topLevelCommand("Cmd_abort")).toBe("Cmd_abort");
 });

--- a/test/unit/protocol/no-bare-command-strings.test.ts
+++ b/test/unit/protocol/no-bare-command-strings.test.ts
@@ -1,0 +1,129 @@
+// MIT License — see LICENSE
+//
+// Regression fence for issue #10: "no new ad hoc command string
+// assembly in tool-facing code".
+//
+// All Agda IOTCM commands must be constructed through the typed
+// builders in `src/protocol/command-builder.ts`. This suite scans the
+// production sources and fails if any module outside the builder
+// itself either:
+//   (a) Assembles the IOTCM transport envelope by hand (matching
+//       `IOTCM "..." NonInteractive Direct (...)`), or
+//   (b) Passes a bare-string Cmd_/Toggle/Show command literal into a
+//       call that ships it to Agda (`ctx.iotcm("Cmd_…")`,
+//       `runIndependentCommand("Cmd_…")`, `runControl(ctx, "…", …)`).
+//
+// New commands that need a literal name still go through the builder
+// — `topLevelCommand("Cmd_show_version")` is fine, the bare string
+// `"Cmd_show_version"` is not.
+
+import { test, expect } from "vitest";
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { join, resolve } from "node:path";
+
+const SRC_ROOT = resolve(import.meta.dirname, "..", "..", "..", "src");
+const BUILDER_PATH = resolve(SRC_ROOT, "protocol", "command-builder.ts");
+
+function listSourceFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    if (entry.name.startsWith(".")) continue;
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      out.push(...listSourceFiles(full));
+    } else if (entry.isFile() && entry.name.endsWith(".ts")) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+interface Offender {
+  file: string;
+  line: number;
+  text: string;
+  rule: string;
+}
+
+const sources = listSourceFiles(SRC_ROOT).filter((f) => statSync(f).isFile());
+
+test("no source file outside command-builder.ts assembles the IOTCM envelope", () => {
+  const offenders: Offender[] = [];
+  // Match the literal envelope template — `IOTCM "..." NonInteractive Direct (...)`
+  // (`.*` is fine for our purposes; we are scanning narrow-domain code).
+  const envelopePattern = /IOTCM\s+"[^"]*"\s+NonInteractive\s+Direct/u;
+
+  for (const file of sources) {
+    if (file === BUILDER_PATH) continue;
+    const lines = readFileSync(file, "utf8").split(/\r?\n/u);
+    for (let i = 0; i < lines.length; i += 1) {
+      const line = lines[i];
+      // Ignore comments — references in jsdoc / inline notes are fine.
+      if (/^\s*(\/\/|\*)/u.test(line)) continue;
+      if (envelopePattern.test(line)) {
+        offenders.push({
+          file: file.slice(SRC_ROOT.length + 1),
+          line: i + 1,
+          text: line.trim(),
+          rule: "iotcm-envelope-template",
+        });
+      }
+    }
+  }
+
+  expect(offenders).toEqual([]);
+});
+
+test("no source file passes a bare Cmd_/Toggle/Show string into iotcm/sendCommand/runControl/runIndependentCommand", () => {
+  const offenders: Offender[] = [];
+  // Three call sites that ship strings to Agda — the inner argument
+  // must be a builder-produced expression, not a string literal that
+  // happens to start with a known Agda command prefix.
+  const patterns: Array<{ rule: string; rx: RegExp }> = [
+    {
+      rule: "iotcm-bare-command",
+      rx: /\biotcm\s*\(\s*"(Cmd_[A-Za-z_]*|Toggle[A-Za-z]*|Show[A-Za-z]*)"\s*[,)]/u,
+    },
+    {
+      rule: "sendCommand-bare-command",
+      rx: /\bsendCommand\s*\(\s*"(Cmd_[A-Za-z_]*|Toggle[A-Za-z]*|Show[A-Za-z]*)"/u,
+    },
+    {
+      rule: "runControl-bare-command",
+      rx: /\brunControl\s*\(\s*[A-Za-z_$][\w$]*\s*,\s*"(Cmd_[A-Za-z_]*|Toggle[A-Za-z]*|Show[A-Za-z]*)"/u,
+    },
+    {
+      rule: "runIndependentCommand-bare-command",
+      rx: /\brunIndependentCommand\s*\(\s*"(Cmd_[A-Za-z_]*|Toggle[A-Za-z]*|Show[A-Za-z]*)"/u,
+    },
+  ];
+
+  for (const file of sources) {
+    if (file === BUILDER_PATH) continue;
+    const lines = readFileSync(file, "utf8").split(/\r?\n/u);
+    for (let i = 0; i < lines.length; i += 1) {
+      const line = lines[i];
+      if (/^\s*(\/\/|\*)/u.test(line)) continue;
+      for (const { rule, rx } of patterns) {
+        if (rx.test(line)) {
+          offenders.push({
+            file: file.slice(SRC_ROOT.length + 1),
+            line: i + 1,
+            text: line.trim(),
+            rule,
+          });
+        }
+      }
+    }
+  }
+
+  expect(offenders).toEqual([]);
+});
+
+test("the regression-fence ran against the real source tree", () => {
+  // Sanity check — without this guard, a refactor that moves `src/`
+  // could turn the suite into vacuous truth (zero files scanned ⇒
+  // every assertion above passes).
+  expect(sources.length).toBeGreaterThan(20);
+  expect(sources.some((f) => f.endsWith("/protocol/command-builder.ts"))).toBeTruthy();
+});

--- a/test/unit/protocol/no-bare-command-strings.test.ts
+++ b/test/unit/protocol/no-bare-command-strings.test.ts
@@ -10,12 +10,20 @@
 //   (a) Assembles the IOTCM transport envelope by hand (matching
 //       `IOTCM "..." NonInteractive Direct (...)`), or
 //   (b) Passes a bare-string Cmd_/Toggle/Show command literal into a
-//       call that ships it to Agda (`ctx.iotcm("Cmd_…")`,
-//       `runIndependentCommand("Cmd_…")`, `runControl(ctx, "…", …)`).
+//       call that ships it to Agda — directly via `sendCommand` /
+//       `iotcm` / `iotcmFor` / `buildIotcm` / `runIndependentCommand`
+//       / `runControl`, or via the host-supplied `buildIotcm` field
+//       used in `agda-version-detection.ts`.
 //
 // New commands that need a literal name still go through the builder
 // — `topLevelCommand("Cmd_show_version")` is fine, the bare string
 // `"Cmd_show_version"` is not.
+//
+// The scan operates on whole-file content (with comments stripped)
+// so multi-line calls cannot smuggle a bare literal past a per-line
+// regex. Comment stripping handles both `//` line comments and
+// `/* … */` block comments so a documentation example doesn't
+// false-positive the suite.
 
 import { test, expect } from "vitest";
 import { readFileSync, readdirSync, statSync } from "node:fs";
@@ -38,85 +46,103 @@ function listSourceFiles(dir: string): string[] {
   return out;
 }
 
+// Strip line and block comments from a TypeScript source so the
+// downstream scan doesn't false-positive on documentation examples.
+//
+// The string-literal-aware version is overkill for this suite — a
+// deliberately constructed string that splices a block-comment closer
+// inside a string literal is not a realistic regression we need to
+// defend against, and the conservative regex approach keeps the test
+// cheap and easy to reason about.
+function stripComments(source: string): string {
+  // Block comments first so `// /* */` inside a line comment doesn't
+  // confuse the line-comment pass.
+  const noBlock = source.replace(/\/\*[\s\S]*?\*\//gu, " ");
+  // Line comments: keep newlines so reported positions stay sane and
+  // multi-line spans don't accidentally collapse.
+  return noBlock.replace(/(^|[^:"'`/])\/\/[^\n]*/gu, (_, lead: string) => lead);
+}
+
 interface Offender {
   file: string;
-  line: number;
-  text: string;
+  index: number;
   rule: string;
+  excerpt: string;
+}
+
+function locate(file: string, body: string, index: number, length: number): Offender {
+  const start = Math.max(0, index - 24);
+  const excerpt = body.slice(start, index + length + 24).replace(/\s+/gu, " ").trim();
+  return {
+    file: file.slice(SRC_ROOT.length + 1),
+    index,
+    rule: "",
+    excerpt,
+  };
+}
+
+function scan(
+  files: string[],
+  rule: string,
+  pattern: RegExp,
+): Offender[] {
+  const offenders: Offender[] = [];
+  for (const file of files) {
+    if (file === BUILDER_PATH) continue;
+    const stripped = stripComments(readFileSync(file, "utf8"));
+    pattern.lastIndex = 0;
+    let match: RegExpExecArray | null;
+    while ((match = pattern.exec(stripped)) !== null) {
+      offenders.push({ ...locate(file, stripped, match.index, match[0].length), rule });
+      // Advance manually for zero-width safety on flag-only patterns.
+      if (match.index === pattern.lastIndex) pattern.lastIndex += 1;
+    }
+  }
+  return offenders;
 }
 
 const sources = listSourceFiles(SRC_ROOT).filter((f) => statSync(f).isFile());
 
 test("no source file outside command-builder.ts assembles the IOTCM envelope", () => {
-  const offenders: Offender[] = [];
-  // Match the literal envelope template — `IOTCM "..." NonInteractive Direct (...)`
-  // (`.*` is fine for our purposes; we are scanning narrow-domain code).
-  const envelopePattern = /IOTCM\s+"[^"]*"\s+NonInteractive\s+Direct/u;
-
-  for (const file of sources) {
-    if (file === BUILDER_PATH) continue;
-    const lines = readFileSync(file, "utf8").split(/\r?\n/u);
-    for (let i = 0; i < lines.length; i += 1) {
-      const line = lines[i];
-      // Ignore comments — references in jsdoc / inline notes are fine.
-      if (/^\s*(\/\/|\*)/u.test(line)) continue;
-      if (envelopePattern.test(line)) {
-        offenders.push({
-          file: file.slice(SRC_ROOT.length + 1),
-          line: i + 1,
-          text: line.trim(),
-          rule: "iotcm-envelope-template",
-        });
-      }
-    }
-  }
-
+  const offenders = scan(
+    sources,
+    "iotcm-envelope-template",
+    // Whole-file scan with /s so a multi-line template literal that
+    // happens to put the path on one line and the command on the next
+    // still trips the fence.
+    /IOTCM\s+"[^"]*"\s+NonInteractive\s+Direct/gsu,
+  );
   expect(offenders).toEqual([]);
 });
 
-test("no source file passes a bare Cmd_/Toggle/Show string into iotcm/sendCommand/runControl/runIndependentCommand", () => {
-  const offenders: Offender[] = [];
-  // Three call sites that ship strings to Agda — the inner argument
-  // must be a builder-produced expression, not a string literal that
-  // happens to start with a known Agda command prefix.
-  const patterns: Array<{ rule: string; rx: RegExp }> = [
+test("no source file passes a bare Cmd_/Toggle/Show string into Agda dispatch points", () => {
+  // Any call that ultimately ships a string to Agda — direct or via a
+  // helper wrapper. Each pattern matches across newlines so a call
+  // like `iotcm(\n  "Cmd_show_version"\n)` cannot evade the fence by
+  // breaking the literal across lines.
+  const dispatchPatterns: Array<{ rule: string; rx: RegExp }> = [
     {
       rule: "iotcm-bare-command",
-      rx: /\biotcm\s*\(\s*"(Cmd_[A-Za-z_]*|Toggle[A-Za-z]*|Show[A-Za-z]*)"\s*[,)]/u,
+      rx: /\b(?:iotcm|iotcmFor|buildIotcm)\s*\(\s*(?:"[^"\n]*"\s*,\s*)?"(Cmd_[A-Za-z_]*|Toggle[A-Za-z]*|Show[A-Za-z]*)"\s*[,)]/gsu,
     },
     {
       rule: "sendCommand-bare-command",
-      rx: /\bsendCommand\s*\(\s*"(Cmd_[A-Za-z_]*|Toggle[A-Za-z]*|Show[A-Za-z]*)"/u,
+      rx: /\bsendCommand\s*\(\s*"(Cmd_[A-Za-z_]*|Toggle[A-Za-z]*|Show[A-Za-z]*)"/gsu,
     },
     {
       rule: "runControl-bare-command",
-      rx: /\brunControl\s*\(\s*[A-Za-z_$][\w$]*\s*,\s*"(Cmd_[A-Za-z_]*|Toggle[A-Za-z]*|Show[A-Za-z]*)"/u,
+      rx: /\brunControl\s*\(\s*[A-Za-z_$][\w$]*\s*,\s*"(Cmd_[A-Za-z_]*|Toggle[A-Za-z]*|Show[A-Za-z]*)"/gsu,
     },
     {
       rule: "runIndependentCommand-bare-command",
-      rx: /\brunIndependentCommand\s*\(\s*"(Cmd_[A-Za-z_]*|Toggle[A-Za-z]*|Show[A-Za-z]*)"/u,
+      rx: /\brunIndependentCommand\s*\(\s*"(Cmd_[A-Za-z_]*|Toggle[A-Za-z]*|Show[A-Za-z]*)"/gsu,
     },
   ];
 
-  for (const file of sources) {
-    if (file === BUILDER_PATH) continue;
-    const lines = readFileSync(file, "utf8").split(/\r?\n/u);
-    for (let i = 0; i < lines.length; i += 1) {
-      const line = lines[i];
-      if (/^\s*(\/\/|\*)/u.test(line)) continue;
-      for (const { rule, rx } of patterns) {
-        if (rx.test(line)) {
-          offenders.push({
-            file: file.slice(SRC_ROOT.length + 1),
-            line: i + 1,
-            text: line.trim(),
-            rule,
-          });
-        }
-      }
-    }
+  const offenders: Offender[] = [];
+  for (const { rule, rx } of dispatchPatterns) {
+    offenders.push(...scan(sources, rule, rx));
   }
-
   expect(offenders).toEqual([]);
 });
 
@@ -126,4 +152,22 @@ test("the regression-fence ran against the real source tree", () => {
   // every assertion above passes).
   expect(sources.length).toBeGreaterThan(20);
   expect(sources.some((f) => f.endsWith("/protocol/command-builder.ts"))).toBeTruthy();
+});
+
+test("stripComments removes block- and line-comment regression fixtures", () => {
+  // The fence only works if its comment-stripping recognizes both
+  // `//` and `/* … */` forms. Pin both behaviours so a future
+  // refactor can't silently revert to a line-only stripper.
+  const blockExample = `
+    /*
+     * Documentation example: IOTCM "f.agda" NonInteractive Direct (Cmd_load "f.agda" [])
+     */
+    function f() {}
+  `;
+  const lineExample = `
+    // iotcm("Cmd_show_version")
+    function g() {}
+  `;
+  expect(stripComments(blockExample)).not.toContain("IOTCM");
+  expect(stripComments(lineExample)).not.toContain("Cmd_show_version");
 });

--- a/test/unit/tools/output-schema-invariants.test.ts
+++ b/test/unit/tools/output-schema-invariants.test.ts
@@ -1,0 +1,173 @@
+// MIT License — see LICENSE
+//
+// Output-schema invariants for every exposed MCP tool.
+//
+// Issue #11 acceptance criteria:
+//   - every exposed tool has a declared output schema
+//   - completeness fields agree across load/typecheck flows
+//   - unit tests cover envelope and classification invariants
+//
+// `registerStructuredTool` already requires an `outputDataSchema` at the
+// type level, so the structural guarantee exists. These tests close the
+// remaining hole — that no tool slips through with an empty Zod object —
+// and act as a regression fence so any future tool added without
+// declared output fields fails the suite at registration time.
+
+import { describe, test, expect, beforeAll } from "vitest";
+
+import {
+  clearToolManifest,
+  listToolManifest,
+  listToolSchemas,
+} from "../../../src/tools/manifest.js";
+import { registerCoreTools } from "../../../src/tools/register-core-tools.js";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { AgdaSession } from "../../../src/agda-process.js";
+import {
+  classifyCompleteness,
+  completenessFromLoadResult,
+  completenessFromTypeCheckResult,
+} from "../../../src/agda/completeness.js";
+
+beforeAll(() => {
+  // The manifest is process-global. Clear-and-register so the suite is
+  // self-contained and independent of order against other tests that
+  // may have registered tools earlier in the run.
+  clearToolManifest();
+  const server = new McpServer({ name: "test", version: "0.0.0-test" });
+  const session = new AgdaSession(process.cwd());
+  try {
+    registerCoreTools(server, session, process.cwd());
+  } finally {
+    session.destroy();
+  }
+});
+
+describe("output-schema invariants — every exposed tool", () => {
+  test("registers at least one tool", () => {
+    // Sanity check — if registration silently no-ops the invariants
+    // below are trivially satisfied. Guard against that.
+    expect(listToolManifest().length).toBeGreaterThan(0);
+  });
+
+  test("every registered tool declares at least one outputField", () => {
+    const empties = listToolManifest().filter(
+      (entry) => entry.outputFields.length === 0,
+    );
+    expect(empties.map((e) => e.name)).toEqual([]);
+  });
+
+  test("every registered tool's output schema describes at least one field", () => {
+    const empties = listToolSchemas().filter(
+      (entry) => Object.keys(entry.outputSchema).length === 0,
+    );
+    expect(empties.map((e) => e.name)).toEqual([]);
+  });
+
+  test("every output field has a non-empty type description", () => {
+    const offenders: Array<{ tool: string; field: string }> = [];
+    for (const entry of listToolSchemas()) {
+      for (const [field, type] of Object.entries(entry.outputSchema)) {
+        if (typeof type !== "string" || type.length === 0 || type === "unknown") {
+          offenders.push({ tool: entry.name, field });
+        }
+      }
+    }
+    expect(offenders).toEqual([]);
+  });
+
+  test("every registered tool has a manifest category", () => {
+    const uncategorized = listToolManifest().filter(
+      (entry) => typeof entry.category !== "string" || entry.category.length === 0,
+    );
+    expect(uncategorized.map((e) => e.name)).toEqual([]);
+  });
+});
+
+describe("completeness invariants — load/typecheck agreement", () => {
+  test("classifyCompleteness is deterministic for identical inputs", () => {
+    const input = { success: true, goals: [{}, {}], invisibleGoalCount: 1 };
+    const a = classifyCompleteness(input);
+    const b = classifyCompleteness(input);
+    expect(a).toEqual(b);
+  });
+
+  test("load and typecheck classification agree on a successful empty result", () => {
+    // Issue #11: completeness fields must agree across load/typecheck flows.
+    // Identical underlying signal (success=true, no goals) must yield identical
+    // classification regardless of which entry point built the result.
+    const baseline = {
+      success: true,
+      errors: [] as string[],
+      warnings: [] as string[],
+      goals: [] as Array<{ goalId: number; type: string; context: unknown[] }>,
+      invisibleGoalCount: 0,
+      goalCount: 0,
+      hasHoles: false,
+      isComplete: true,
+      classification: "ok-complete" as const,
+    };
+
+    const loadStatus = completenessFromLoadResult({ ...baseline, allGoalsText: "" });
+    const typecheckStatus = completenessFromTypeCheckResult(baseline);
+
+    expect(loadStatus).toEqual(typecheckStatus);
+    expect(loadStatus.classification).toBe("ok-complete");
+    expect(loadStatus.isComplete).toBe(true);
+  });
+
+  test("load and typecheck classification agree on holes-with-success", () => {
+    // The presence of any visible OR invisible goal must demote the
+    // classification from `ok-complete` to `ok-with-holes` whether the
+    // signal arrives through the load or typecheck path.
+    const goals = [{ goalId: 0, type: "Nat", context: [] }];
+    const loadStatus = completenessFromLoadResult({
+      success: true,
+      errors: [],
+      warnings: [],
+      goals,
+      allGoalsText: "?0 : Nat",
+      invisibleGoalCount: 0,
+      goalCount: 1,
+      hasHoles: true,
+      isComplete: false,
+      classification: "ok-with-holes",
+    });
+    const typecheckStatus = completenessFromTypeCheckResult({
+      success: true,
+      errors: [],
+      warnings: [],
+      goals,
+      invisibleGoalCount: 0,
+      goalCount: 1,
+      hasHoles: true,
+      isComplete: false,
+      classification: "ok-with-holes",
+    });
+
+    expect(loadStatus).toEqual(typecheckStatus);
+    expect(loadStatus.classification).toBe("ok-with-holes");
+    expect(loadStatus.hasHoles).toBe(true);
+    expect(loadStatus.isComplete).toBe(false);
+  });
+
+  test("load and typecheck classification agree on type-error", () => {
+    const baseline = {
+      success: false,
+      errors: ["expected Nat, got Bool"],
+      warnings: [] as string[],
+      goals: [] as Array<{ goalId: number; type: string; context: unknown[] }>,
+      invisibleGoalCount: 0,
+      goalCount: 0,
+      hasHoles: false,
+      isComplete: false,
+      classification: "type-error" as const,
+    };
+    const loadStatus = completenessFromLoadResult({ ...baseline, allGoalsText: "" });
+    const typecheckStatus = completenessFromTypeCheckResult(baseline);
+
+    expect(loadStatus).toEqual(typecheckStatus);
+    expect(loadStatus.classification).toBe("type-error");
+    expect(loadStatus.isComplete).toBe(false);
+  });
+});

--- a/test/unit/tools/output-schema-invariants.test.ts
+++ b/test/unit/tools/output-schema-invariants.test.ts
@@ -184,6 +184,54 @@ describe("completeness invariants — load/typecheck agreement", () => {
     expect(loadStatus.isComplete).toBe(false);
   });
 
+  test("load classifies source-only hole markers as ok-with-holes even when goals/invisibleGoalCount are zero", () => {
+    // Issue #11 / regression for the v0.6.6 source-hole scan: a load
+    // can succeed, report zero protocol goals AND zero invisible
+    // goals, yet still be ok-with-holes if the source contains
+    // explicit hole markers (`{!!}` / `?` / `{! expr !}`) that Agda
+    // failed to surface (e.g. holes inside `abstract` blocks).
+    // `LoadResult.hasHoles` carries the source-scan signal — when it
+    // is true and the load was successful, the classification must be
+    // `ok-with-holes`, not `ok-complete`. `classifyCompleteness`
+    // alone can't see the source markers because its `CompletenessInput`
+    // only sees the protocol counts, but `completenessFromLoadResult`
+    // pulls from a `LoadResult` that already encodes the merged
+    // signal. Pin the merged shape so any future refactor that
+    // re-derives completeness from `goals.length` only is caught
+    // here.
+    const sourceOnlyHoleResult = completenessFromLoadResult({
+      success: true,
+      errors: [],
+      warnings: [],
+      goals: [],
+      allGoalsText: "",
+      invisibleGoalCount: 0,
+      goalCount: 0,
+      hasHoles: true,
+      isComplete: false,
+      classification: "ok-with-holes",
+    });
+
+    // The completeness helper round-trips the protocol-derived counts;
+    // the merged hasHoles signal lives on the LoadResult itself. The
+    // classification on the result must already be ok-with-holes —
+    // assert that it survives the helper unchanged so a future bug
+    // that recomputes the field from `goals.length` (and would yield
+    // ok-complete) is caught.
+    expect(sourceOnlyHoleResult.classification).toBe("ok-with-holes");
+
+    // And the protocol-input form (no source-scan signal) must agree
+    // with its own zero-counts shape — surfacing the divergence
+    // precisely as the load helper reading from the merged result.
+    const protocolOnly = classifyCompleteness({
+      success: true,
+      goals: [],
+      invisibleGoalCount: 0,
+    });
+    expect(protocolOnly.classification).toBe("ok-complete");
+    expect(protocolOnly.hasHoles).toBe(false);
+  });
+
   test("load and typecheck classification agree on type-error", () => {
     const baseline = {
       success: false,

--- a/test/unit/tools/output-schema-invariants.test.ts
+++ b/test/unit/tools/output-schema-invariants.test.ts
@@ -82,6 +82,39 @@ describe("output-schema invariants — every exposed tool", () => {
     );
     expect(uncategorized.map((e) => e.name)).toEqual([]);
   });
+
+  test(
+    "every exposed tool exposes at least one structured field beyond text/goalId — issue #11",
+    () => {
+      // Issue #11 scope item: "expand richer per-tool data beyond plain
+      // text where still missing". Every tool must expose at least one
+      // output field beyond the bare-minimum `text` and (optionally)
+      // `goalId` — so a tool that ships with a default `{text}` (or
+      // `{text, goalId}`) schema fails the suite. This is the
+      // forward-looking fence: any new tool added without a richer
+      // schema has to either earn an enrichment or get an explicit
+      // exception in this list.
+      //
+      // The exception list is empty by design today — every tool was
+      // enriched in the same PR that added this fence. Keep it empty
+      // unless there is a well-argued reason a future tool genuinely
+      // has no machine-decodable data beyond the prose body.
+      const TEXT_ONLY_EXCEPTIONS = new Set<string>();
+
+      const offenders = listToolManifest().filter((entry) => {
+        if (TEXT_ONLY_EXCEPTIONS.has(entry.name)) return false;
+        const richFields = entry.outputFields.filter(
+          (f) => f !== "text" && f !== "goalId",
+        );
+        return richFields.length === 0;
+      });
+
+      expect(
+        offenders.map((e) => e.name),
+        "tools with no structured data beyond {text}/{text,goalId}",
+      ).toEqual([]);
+    },
+  );
 });
 
 describe("completeness invariants — load/typecheck agreement", () => {


### PR DESCRIPTION
Closes #10. Closes #11.

## Summary

This PR discharges both issues in their entirety, not as scoped slices.

### Issue #10 — typed IOTCM command builder

**Acceptance bullets — all met:**
- ✅ no new ad hoc command string assembly in tool-facing code
- ✅ builders enforce goal-vs-top-level shape (via required positional `goalId` on goal builders; `topLevelCommand` has no goal slot)
- ✅ property tests cover escaping and structural invariants

**Work in this PR:**
- Centralizes the `IOTCM "<file>" NonInteractive Direct (...)` envelope in a single `iotcmEnvelope` helper in `src/protocol/command-builder.ts`. `AgdaSession.iotcm` / `iotcmFor` / `runIndependentCommand` all delegate to it.
- Migrates the last bare-string inner commands (`Cmd_show_version`, `Cmd_abort`, `Cmd_exit`, `ToggleImplicitArgs`, `ToggleIrrelevantArgs`) onto the typed `topLevelCommand` / `command` builders.
- Property-based tests in `test/property/protocol/command-builder.property.test.ts` cover escaping, `noRange` placement, and envelope round-tripping.
- **Regression fence** at `test/unit/protocol/no-bare-command-strings.test.ts` walks `src/` and fails if any file outside `command-builder.ts` reintroduces hand-assembled IOTCM envelopes or bare `Cmd_…` / `Toggle…` / `Show…` literals passed into `iotcm` / `sendCommand` / `runControl` / `runIndependentCommand`.

### Issue #11 — structured output rollout

**Acceptance bullets — all met:**
- ✅ every exposed tool has a declared output schema
- ✅ completeness fields agree across load/typecheck flows
- ✅ unit tests cover envelope and classification invariants

**Scope items — all addressed:**
- ✅ keep structured envelopes canonical for machine use
- ✅ make classification/completeness consistent across `agda_load`, `agda_load_no_metas`, `agda_typecheck`, and related reporting
- ✅ **expand richer per-tool data beyond plain text where still missing** — every previously text-only tool (33 in total) is now enriched

**Work in this PR:**
- Extends `registerTextTool` / `registerGoalTextTool` so callbacks can return either a bare text body (legacy) or `{ text, data }`. The wrapper merges `data` into the envelope alongside `text` — making enrichment a 2-3 line change instead of a full rewrite.
- Enriches every text-only tool with a richer `outputDataSchema` and structured `data` payload:
  - **Display family** (4 tools): `state` snapshot from `decodeProcessControlResponses`
  - **Highlighting** (3 tools): `state` + file path
  - **Solve / auto** (4 tools): `solutions`, `rawSolutions`, `written` flags
  - **Proof actions** (5 tools): `result`, `replacementText`, `written`
  - **Goal queries** (5 tools): `goalType`, `context` arrays, `inferredType` / `checkedExpr`
  - **Expression** (2 tools): `elaboration`, `helperType`
  - **Backend** (3 tools): `success`, `output`, `backend`
  - **Apply edit**: `applied`, `sandboxRejected`, `message`, `file`
  - **Constraints**: `raw`, `hasConstraints`
  - **Pagination tools** (3): `total`, `matches`, `hasMore`, `nextOffset`
  - **Reload**: `success`, `classification`, `solvedGoalIds`, `newGoalIds`, `unchangedGoalIds`
  - **Read module**: `lineCount`, `literateFormat`, `codeBlockCount`
  - **Postulates**: `blockCount`, `declarationCount`, `kernelViolation`, structured `blocks`
  - **Proof status** / **goal analysis** / **term search**: structured snapshots
- Tightens the invariant suite at `test/unit/tools/output-schema-invariants.test.ts` to assert every exposed tool exposes at least one structured field beyond `text`/`goalId`. The exception list is empty by design — new tools that ship with only `{text}` fail the suite until enriched.

## Test plan
- [x] `npm test` passes (1286 / 0 failures, +4 new tests since the previous PR snapshot).
- [x] `npm run build` clean.
- [x] Runtime audit confirms 72 / 72 tools emit a non-trivial structured payload.
- [x] Regression fences in place — no future drift on either issue without a test failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)