### PR TITLE
fix(load): harden load terminus (v0.6.8) — fatal-stderr, inactivity timeout, strict false-green

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,17 @@ and this project follows [Semantic Versioning](https://semver.org/).
   `type-error` — at the classification layer, so the pass/fail contract
   is unchanged but completion waits for Agda's real goal state.
 
+- **Reloading after a dependency changed no longer reports a stale clean
+  result (issues #61, #64).** Editing an imported module and reloading a
+  dependent triggers a rebuild of that dependency; while the rebuild runs
+  Agda streams `Checking <dep>` and then falls silent for as long as the
+  rebuild takes. The old idle heuristic could mistake that silence for
+  completion and re-report the previous `ok-complete`, hiding an error
+  the changed dependency now introduces. The goal-state terminus wait
+  makes the reload hold until the rebuild's real result is on the wire.
+  A gated integration test reproduces the race with a deliberately slow,
+  silent dependency rebuild.
+
 ## [0.6.7] - 2026-05-13
 
 ### Notes for upgraders

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,11 +21,40 @@ and this project follows [Semantic Versioning](https://semver.org/).
   mis-reported. The fix makes a `Cmd_load` withhold idle completion until
   those goal-state responses are actually on the wire; completion then
   comes from the goal state itself, a process exit, or the per-command
-  timeout. Only `agda_load`'s `Cmd_load` opts in — `agda_load_no_metas`,
-  give, case-split, and queries are unchanged, and a fast load whose goal
-  state arrives promptly sees no extra latency. Prior load-success state
-  (classification, goal IDs) is also invalidated at the start of every
-  load so a failed load can't leave stale success visible.
+  timeout. `agda_load` and `agda_load_no_metas` both wait for the goal
+  state (see the strict-load entry below); give, case-split, and queries
+  are unchanged, and a fast load whose goal state arrives promptly sees
+  no extra latency. Prior load-success state (classification, goal IDs)
+  is also invalidated at the start of every load so a failed load can't
+  leave stale success visible.
+
+- **`agda_load` no longer hangs the full command timeout when Agda
+  rejects the command itself.** A malformed IOTCM (or one Agda "cannot
+  read") is answered on the JSON channel with a `cannot read: …` notice
+  and no goal state — but the process stays alive. With the goal-state
+  wait above, the load then waited out the entire per-command timeout
+  before failing. A fatal protocol stderr (`cannot read:`, `failed to
+  parse`, `invalid …`) is now treated as a load terminus, so the load
+  fails fast with Agda's own message instead of stalling.
+
+- **The per-command timeout now measures inactivity, not total elapsed
+  time.** It was an absolute deadline from command start, so a healthy
+  cold load still streaming progress at the deadline was killed and the
+  subprocess respawned. It is now an inactivity watchdog that resets on
+  every response, firing only after a full quiet window — a genuinely
+  wedged process is still reaped, but a slow-but-progressing load is not.
+
+- **`agda_load_no_metas` no longer reports a clean load before Agda
+  finishes (strict false-green).** A clean `Cmd_load_no_metas` emits no
+  goal-state terminus at all — only a `Checking <module>` line, then
+  silence until it finishes — so its completion could only be inferred
+  from an idle gap. A module that type-checks silently for longer than
+  that gap was resolved mid-check as `ok-complete`, hiding holes or
+  errors past the pause. The strict load now runs over `Cmd_load` (which
+  always emits `InteractionPoints` + `AllGoalsWarnings`, or an `Error`)
+  and applies the same strict rejection — any hole or unsolved meta is a
+  `type-error` — at the classification layer, so the pass/fail contract
+  is unchanged but completion waits for Agda's real goal state.
 
 ## [0.6.7] - 2026-05-13
 

--- a/src/agda/protocol-errors.ts
+++ b/src/agda/protocol-errors.ts
@@ -7,10 +7,20 @@ const FATAL_PROTOCOL_PATTERNS = [
   /^invalid\b/i,
 ];
 
+/** True when stderr text is Agda rejecting the command itself (a
+ *  malformed IOTCM it "cannot read", etc.) rather than reporting on the
+ *  file. Agda emits this and keeps running without any goal state, so
+ *  the transport must treat it as a load terminus or it waits the full
+ *  command timeout for responses that never come. */
+export function isFatalProtocolStderr(text: string): boolean {
+  const trimmed = text.trim();
+  return FATAL_PROTOCOL_PATTERNS.some((pattern) => pattern.test(trimmed));
+}
+
 export function throwOnFatalProtocolStderr(responses: AgdaResponse[]): void {
   const fatal = decodeStderrOutputs(responses)
     .map((text) => text.trim())
-    .filter((text) => FATAL_PROTOCOL_PATTERNS.some((pattern) => pattern.test(text)));
+    .filter((text) => isFatalProtocolStderr(text));
 
   if (fatal.length > 0) {
     throw new Error(fatal.join("\n"));

--- a/src/agda/session-load-impl.ts
+++ b/src/agda/session-load-impl.ts
@@ -40,9 +40,9 @@ export { buildLoadOptionsList };
 //  3. Source hole markers — our fallback scan when the protocol reports
 //     zero visible and zero invisible goals but the source has {!!}/?.
 //
-// Postulates are complete, not holes. Cmd_load_no_metas is stricter:
-// any remaining interaction point, invisible goal, or source hole forces
-// a type-error.
+// Postulates are complete, not holes. The strict load (agda_load_no_metas)
+// is stricter: any remaining interaction point, invisible goal, or source
+// hole forces a type-error.
 
 /** Record an early-return classification on the session and return the
  *  result. Keeps the proc-died / incomplete exits consistent with the
@@ -175,16 +175,32 @@ export async function runLoadNoMetas(
     return finalizeEarlyReturn(session, fileNotFound(absPath));
   }
 
-  // No awaitGoalTerminus / terminus guard here: Cmd_load_no_metas
-  // deliberately skips the metas display, so a clean strict load emits no
-  // InteractionPoints / AllGoalsWarnings at all (only highlighting +
-  // Status). It's outside the documented Cmd_load goal-state sequence, so
-  // "no terminus" is normal completion, not truncation.
+  // Strict load via Cmd_load, not Cmd_load_no_metas. A clean
+  // Cmd_load_no_metas emits no goal-state terminus at all — only a
+  // "Checking <module>" line, then silence until it finishes — so its
+  // completion can only be guessed from an idle gap, which a slow
+  // module's silent type-checking pause defeats (resolving mid-check as a
+  // false success). Cmd_load always emits InteractionPoints +
+  // AllGoalsWarnings (or an Error), giving the transport a real terminus;
+  // we then reject any hole or unsolved meta at the classification layer,
+  // which reproduces Cmd_load_no_metas's pass/fail exactly.
   const responses = await session.sendCommand(
-    session.iotcmFor(absPath, command("Cmd_load_no_metas", quoted(absPath))),
+    session.iotcmFor(absPath, command("Cmd_load", quoted(absPath), "[]")),
+    undefined,
+    { awaitGoalTerminus: true },
   );
   throwOnFatalProtocolStderr(responses);
   const parsed: ParsedLoadResult = parseLoadResponses(responses, { profilingEnabled: false });
+
+  // The transport waits for Agda's goal-state responses, so their absence
+  // means the process ended before finishing. Fail loudly rather than
+  // report a fabricated strict success.
+  if (!parsed.sawLoadTerminus) {
+    throw new Error(
+      `Agda process ended before completing the strict load of ${absPath} ` +
+      `(no goals or type error were emitted). Re-issue agda_load_no_metas.`,
+    );
+  }
 
   const needsExplicitHoleScan =
     parsed.success && parsed.goalCount === 0 && parsed.invisibleGoalCount === 0;

--- a/src/session/agda-transport.ts
+++ b/src/session/agda-transport.ts
@@ -12,11 +12,11 @@ import {
   idleCompletionDelay,
   shouldResolveOnIdle,
   summarizeResponseKinds,
-  tailResponsePreview,
   trailingResponseDelay,
 } from "./command-completion.js";
 import { parseAgdaStdoutLine } from "./stdout-line.js";
 import { GoalTerminusTracker } from "./goal-terminus.js";
+import { waitDiagnostics as buildWaitDiagnostics } from "./command-wait-diagnostics.js";
 
 /**
  * Marker error raised when an in-flight `transport.sendCommand` is
@@ -56,6 +56,10 @@ export class AgdaTransport {
   private sawStatusDone = false;
   private idleDoneTimer: NodeJS.Timeout | null = null;
   private controlEscalationTimer: NodeJS.Timeout | null = null;
+  // Re-arms the in-flight command's inactivity timeout on each response so
+  // the timeout measures silence, not elapsed time. Set only during a
+  // regular sendCommand; null otherwise.
+  private resetInactivityTimer: (() => void) | null = null;
   private lastResponseAt: number | null = null;
   private lastResponseKind: string | null = null;
   // When set (a Cmd_load), hold idle completion until the goal-state
@@ -122,6 +126,7 @@ export class AgdaTransport {
     this.lastResponseAt = null;
     this.lastResponseKind = null;
     this.awaitGoalTerminus = false;
+    this.resetInactivityTimer = null;
     this.rejectInFlightCommand("AgdaTransport destroyed while command was in flight");
   }
 
@@ -148,18 +153,13 @@ export class AgdaTransport {
   }
 
   /** Write a fire-and-forget IOTCM control command (`Cmd_abort` /
-   *  `Cmd_exit`) and resolve after a short flush window. The Promise
-   *  itself never rejects — Agda may legitimately emit no response,
-   *  or emit a delayed `DoneAborting`/`DoneExiting` we capture if
-   *  it arrives in time.
-   *
-   *  Background safety net: if `armEscalation` is true and
-   *  `escalationMs > 0`, an `unref()`'d timer terminates the proc
-   *  after `escalationMs` unless it closes or emits a control-echo
-   *  (cleared in `recordCollectedResponse`). The caller decides
-   *  whether to arm: `Cmd_exit` always arms; `Cmd_abort` arms only
-   *  if a regular command was actually interrupted (an idle abort
-   *  is a protocol no-op and must NOT kill a healthy proc). */
+   *  `Cmd_exit`) and resolve after a short flush window. Never rejects —
+   *  Agda may emit no response, or a delayed `DoneAborting`/`DoneExiting`.
+   *  When `armEscalation` and `escalationMs > 0`, an `unref()`'d timer
+   *  terminates the proc after `escalationMs` unless it closes or emits a
+   *  control-echo. Caller decides: `Cmd_exit` always arms; `Cmd_abort`
+   *  arms only if it interrupted an in-flight command (an idle abort is a
+   *  no-op and must not kill a healthy proc). */
   sendFireAndForgetCommand(
     proc: ChildProcess,
     command: string,
@@ -173,23 +173,13 @@ export class AgdaTransport {
       escalationMs,
       armEscalation: options.armEscalation,
     });
-    // Interrupt any in-flight `sendCommand` before we clobber the
-    // shared `buffer`/`responseQueue`/`collecting` state. The
-    // session path has usually already done this synchronously
-    // before queueing us, so by the time we run there is no
-    // emitter listener left and this is a no-op; the redundant
-    // call is defense for direct-transport callers (and unit
-    // tests) that bypass the session.
-    //
-    // We do NOT trust the boolean return to gate the escalation
-    // timer here — by the time this fire-and-forget task runs
-    // through the session command queue, the in-flight that
-    // motivated the abort is long gone, and the listener-count
-    // check would always be false. The caller passes
-    // `armEscalation` explicitly based on what it observed at the
-    // moment the control command was *requested*. See
-    // `dispatchSessionControlCommand` in
-    // `session-command-dispatch.ts`.
+    // Interrupt any in-flight `sendCommand` before clobbering the shared
+    // buffer/queue/collecting state. Usually already done synchronously by
+    // the session path (so this is a no-op); the redundant call defends
+    // direct-transport callers and tests. The escalation timer is gated by
+    // the caller's explicit `armEscalation`, not this return value — by now
+    // the motivating in-flight is gone and the listener check is always
+    // false. See `dispatchSessionControlCommand`.
     this.rejectInFlightCommand(
       "Interrupted by Agda control command",
       { controlCommand: true },
@@ -202,6 +192,8 @@ export class AgdaTransport {
     this.lastResponseAt = null;
     this.lastResponseKind = null;
     this.awaitGoalTerminus = false;
+    // Control commands use the flush window; drop any stale watchdog re-arm.
+    this.resetInactivityTimer = null;
 
     // Kill-escalation fallback for a wedged Agda that fails to
     // service the control command. Caller decides when to arm:
@@ -285,24 +277,17 @@ export class AgdaTransport {
       const sentryIntervalMs = configuredWaitingSentryMs();
       const waitingSentry = sentryIntervalMs > 0
         ? setInterval(() => {
-            logger.warn("sendCommand still waiting", {
-              command: command.slice(0, 100),
-              elapsedMs: Date.now() - startTime,
-              responseCount: this.responseQueue.length,
-              sawStatusDone: this.sawStatusDone,
-              msSinceLastResponse: this.lastResponseAt === null
-                ? null
-                : Date.now() - this.lastResponseAt,
-              lastResponseKind: this.lastResponseKind,
-              responseKinds: summarizeResponseKinds(this.responseQueue),
-              responseTail: tailResponsePreview(this.responseQueue),
-            });
+            logger.warn("sendCommand still waiting", this.waitDiagnostics(command, startTime));
           }, sentryIntervalMs)
         : null;
+
+      let inactivityTimer: NodeJS.Timeout;
 
       const finish = (handler: () => void) => {
         this.collecting = false;
         this.clearIdleCompletionTimer();
+        clearTimeout(inactivityTimer);
+        this.resetInactivityTimer = null;
         if (waitingSentry) {
           clearInterval(waitingSentry);
         }
@@ -311,31 +296,29 @@ export class AgdaTransport {
         handler();
       };
 
-      const timeout = setTimeout(() => {
+      const onTimeout = () => {
         const responseCount = this.responseQueue.length;
         const responseKinds = summarizeResponseKinds(this.responseQueue);
-        logger.warn("sendCommand timed out", {
-          command: command.slice(0, 100),
-          timeoutMs,
-          responseCount,
-          sawStatusDone: this.sawStatusDone,
-          elapsedMs: Date.now() - startTime,
-          msSinceLastResponse: this.lastResponseAt === null
-            ? null
-            : Date.now() - this.lastResponseAt,
-          lastResponseKind: this.lastResponseKind,
-          responseKinds,
-          responseTail: tailResponsePreview(this.responseQueue),
-        });
+        logger.warn("sendCommand timed out", this.waitDiagnostics(command, startTime, timeoutMs));
         terminateAgdaProcess(proc);
         this.buffer = "";
         finish(() => {
           rejectCmd(new Error(
-            `sendCommand timed out after ${timeoutMs}ms ` +
+            `sendCommand timed out after ${timeoutMs}ms of inactivity ` +
             `(received ${responseCount} responses: ${JSON.stringify(responseKinds)})`,
           ));
         });
-      }, timeoutMs);
+      };
+
+      // Inactivity watchdog: reset on each response so it fires only after
+      // `timeoutMs` of silence, not of total work. A dead proc still gets
+      // reaped; a slow module emitting progress does not.
+      const armTimeout = () => {
+        clearTimeout(inactivityTimer);
+        inactivityTimer = setTimeout(onTimeout, timeoutMs);
+      };
+      this.resetInactivityTimer = armTimeout;
+      armTimeout();
 
       const onDone = (origin: CommandCompletionOrigin = "signal") => {
         const trailingDelay = trailingResponseDelay({
@@ -345,7 +328,6 @@ export class AgdaTransport {
         }, origin);
 
         setTimeout(() => {
-          clearTimeout(timeout);
           finish(() => {
             const responses = [...this.responseQueue];
             logger.trace("sendCommand done", {
@@ -358,7 +340,6 @@ export class AgdaTransport {
       };
 
       const onError = (err: Error) => {
-        clearTimeout(timeout);
         finish(() => {
           rejectCmd(err);
         });
@@ -449,7 +430,26 @@ export class AgdaTransport {
     }
     if (this.awaitGoalTerminus) this.goalTerminus.record(response);
 
+    // Progress arrived — push back the inactivity watchdog.
+    this.resetInactivityTimer?.();
     this.bumpIdleCompletionTimer();
+  }
+
+  private waitDiagnostics(
+    command: string,
+    startTime: number,
+    timeoutMs?: number,
+  ): Record<string, unknown> {
+    return buildWaitDiagnostics({
+      command,
+      startTimeMs: startTime,
+      nowMs: Date.now(),
+      responseQueue: this.responseQueue,
+      sawStatusDone: this.sawStatusDone,
+      lastResponseAt: this.lastResponseAt,
+      lastResponseKind: this.lastResponseKind,
+      timeoutMs,
+    });
   }
 
   private clearIdleCompletionTimer(): void {

--- a/src/session/command-wait-diagnostics.ts
+++ b/src/session/command-wait-diagnostics.ts
@@ -1,0 +1,41 @@
+// MIT License — see LICENSE
+//
+// Shared shape for the "still waiting" sentry log and the timeout log in
+// AgdaTransport.sendCommand. Both describe the same in-flight snapshot, so
+// keeping the field set in one place avoids the two drifting apart.
+
+import {
+  summarizeResponseKinds,
+  tailResponsePreview,
+  type ResponseLike,
+} from "./command-completion.js";
+
+export interface WaitDiagnosticsInput {
+  command: string;
+  startTimeMs: number;
+  nowMs: number;
+  responseQueue: ResponseLike[];
+  sawStatusDone: boolean;
+  lastResponseAt: number | null;
+  lastResponseKind: string | null;
+  timeoutMs?: number;
+}
+
+export function waitDiagnostics(input: WaitDiagnosticsInput): Record<string, unknown> {
+  const diag: Record<string, unknown> = {
+    command: input.command.slice(0, 100),
+    responseCount: input.responseQueue.length,
+    sawStatusDone: input.sawStatusDone,
+    elapsedMs: input.nowMs - input.startTimeMs,
+    msSinceLastResponse: input.lastResponseAt === null
+      ? null
+      : input.nowMs - input.lastResponseAt,
+    lastResponseKind: input.lastResponseKind,
+    responseKinds: summarizeResponseKinds(input.responseQueue),
+    responseTail: tailResponsePreview(input.responseQueue),
+  };
+  if (input.timeoutMs !== undefined) {
+    diag.timeoutMs = input.timeoutMs;
+  }
+  return diag;
+}

--- a/src/session/goal-terminus.ts
+++ b/src/session/goal-terminus.ts
@@ -6,18 +6,25 @@
 // Error on failure. The transport uses `reached()` to withhold idle
 // completion until then, so a slow module's silent type-checking gap
 // can't be mistaken for the end of the command.
+//
+// A fatal protocol stderr (Agda rejecting the command it "cannot read")
+// is also a terminus: Agda keeps running but emits no goal state, so
+// without this the load would wait the full command timeout.
 
 import type { AgdaResponse } from "../agda/types.js";
+import { isFatalProtocolStderr } from "../agda/protocol-errors.js";
 
 export class GoalTerminusTracker {
   private sawInteractionPoints = false;
   private sawAllGoalsWarnings = false;
   private sawError = false;
+  private sawFatalStderr = false;
 
   reset(): void {
     this.sawInteractionPoints = false;
     this.sawAllGoalsWarnings = false;
     this.sawError = false;
+    this.sawFatalStderr = false;
   }
 
   /** Record one response via cheap kind reads (no schema parse). */
@@ -28,10 +35,19 @@ export class GoalTerminusTracker {
       const infoKind = (response.info as { kind?: unknown } | undefined)?.kind;
       if (infoKind === "AllGoalsWarnings") this.sawAllGoalsWarnings = true;
       else if (infoKind === "Error") this.sawError = true;
+    } else if (response.kind === "StderrOutput") {
+      const text = (response as { text?: unknown }).text;
+      if (typeof text === "string" && isFatalProtocolStderr(text)) {
+        this.sawFatalStderr = true;
+      }
     }
   }
 
   reached(): boolean {
-    return this.sawError || (this.sawInteractionPoints && this.sawAllGoalsWarnings);
+    return (
+      this.sawError ||
+      this.sawFatalStderr ||
+      (this.sawInteractionPoints && this.sawAllGoalsWarnings)
+    );
   }
 }

--- a/src/session/register-agda-load-no-metas.ts
+++ b/src/session/register-agda-load-no-metas.ts
@@ -2,11 +2,14 @@
 //
 // agda_load_no_metas tool registration.
 //
-// Thin variant of agda_load that uses Cmd_load_no_metas, which fails
-// the load if any unsolved metavariables remain after scope-checking.
-// Cmd_load_no_metas does not accept per-load command-line options, so
-// profileOptions is deliberately not exposed here — callers who need
-// profiling should use agda_load.
+// Strict variant of agda_load: it fails the load if any hole or unsolved
+// metavariable remains. Implemented over Cmd_load (which emits a real
+// goal-state terminus) with strict rejection applied at the
+// classification layer — a clean Cmd_load_no_metas emits no terminus, so
+// its completion could only be guessed from an idle gap and a slow
+// module's silent type-check could resolve it mid-load as a false
+// success. profileOptions is deliberately not exposed here — callers who
+// need profiling should use agda_load.
 
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
@@ -41,9 +44,9 @@ export function registerAgdaLoadNoMetas(
   registerStructuredTool({
     server,
     name: "agda_load_no_metas",
-    description: "Load and type-check an Agda file, failing if unsolved metavariables remain after loading. Note: Cmd_load_no_metas does not accept command-line options, so Agda profiling options cannot be passed directly. Use agda_load with profileOptions for profiled type-checking.",
+    description: "Load and type-check an Agda file strictly, failing if any hole or unsolved metavariable remains after loading. Profiling options are not supported here; use agda_load with profileOptions for profiled type-checking.",
     category: "session",
-    protocolCommands: ["Cmd_load_no_metas"],
+    protocolCommands: ["Cmd_load"],
     requiresLoadedSession: false,
     inputSchema: {
       file: z.string().describe(filePathDescription(session.getAgdaVersion() ?? undefined)),
@@ -108,7 +111,7 @@ export function registerAgdaLoadNoMetas(
               ...result.warnings.map((message) => warningDiagnostic(message, "agda-warning")),
             ],
             stale: session.isFileStale() || undefined,
-            provenance: { file: filePath, protocolCommands: ["Cmd_load_no_metas"] },
+            provenance: { file: filePath, protocolCommands: ["Cmd_load"] },
             elapsedMs,
           }),
           text,

--- a/test/integration/agda/agda-stale-dependency.test.ts
+++ b/test/integration/agda/agda-stale-dependency.test.ts
@@ -1,0 +1,96 @@
+import { test, expect } from "vitest";
+import { mkdtempSync, writeFileSync, utimesSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { AgdaSession } from "../../../src/agda-process.js";
+import { detectAgdaVersion } from "../../helpers/agda-version.js";
+
+const agdaAvailable = detectAgdaVersion() !== undefined;
+const it = agdaAvailable && process.env.RUN_AGDA_INTEGRATION === "1" ? test : test.skip;
+
+// Regression for the stale-dependency false-green (issues #61 / #64):
+// load A (depends on B) clean, then break B on disk and reload A. A correct
+// reload must rebuild B and surface the resulting error — never re-report the
+// previous clean result. The pre-fix idle-completion path could resolve the
+// reload before the dependency's rebuild error reached the wire, reporting a
+// fabricated `ok-complete`. The goal-state terminus wait closes that gap.
+//
+// The dependency contains a deliberately slow, SILENT check (forced
+// normalization of ack(3,8) against its literal numeral, so `refl` cannot
+// short-circuit). That reproduces the actual race: Agda emits `Checking B`
+// and then nothing for seconds while it rebuilds, which is exactly the gap
+// the old idle heuristic mistook for completion. With the terminus wait the
+// reload is correct regardless of how long that silent gap runs.
+
+function acker(m: number, n: number): number {
+  const memo = new Map<string, number>();
+  const a = (x: number, y: number): number => {
+    const k = `${x},${y}`;
+    const hit = memo.get(k);
+    if (hit !== undefined) return hit;
+    const v = x === 0 ? y + 1 : y === 0 ? a(x - 1, 1) : a(x - 1, a(x, y - 1));
+    memo.set(k, v);
+    return v;
+  };
+  return a(m, n);
+}
+const nat = (n: number) => `${"suc (".repeat(n)}zero${")".repeat(n)}`;
+const PRELUDE =
+  "data Nat : Set where\n  zero : Nat\n  suc  : Nat -> Nat\n" +
+  "ack : Nat -> Nat -> Nat\n" +
+  "ack zero    b       = suc b\n" +
+  "ack (suc a) zero    = ack a (suc zero)\n" +
+  "ack (suc a) (suc b) = ack a (ack (suc a) b)\n" +
+  "data _==_ {A : Set}(x : A) : A -> Set where\n  refl : x == x\n";
+// A slow, silent normalization that passes — the rebuild spends seconds here.
+const SLOW =
+  `M : Nat\nM = ${nat(3)}\nN : Nat\nN = ${nat(8)}\nK : Nat\nK = ${nat(acker(3, 8))}\n` +
+  "slow : ack M N == K\nslow = refl\n";
+
+const B_OK = `module B where\n${PRELUDE}${SLOW}foo : Nat\nfoo = zero\n`;
+// foo is retyped to Set, so A's `bar : Nat := foo` becomes ill-typed.
+const B_BROKEN = `module B where\n${PRELUDE}${SLOW}foo : Set\nfoo = Nat\n`;
+const A_SRC = `module A where
+
+open import B
+
+bar : Nat
+bar = foo
+`;
+
+it("a broken dependency reloads as type-error, not a stale false-green", async () => {
+  const root = mkdtempSync(join(tmpdir(), "stale-dep-"));
+  const agdaDir = mkdtempSync(join(tmpdir(), "stale-dep-adir-"));
+  writeFileSync(join(root, "B.agda"), B_OK);
+  writeFileSync(join(root, "A.agda"), A_SRC);
+
+  // Isolated, empty AGDA_DIR so no ambient ~/.agda libraries/defaults are
+  // read — the two self-contained modules need none.
+  const prevAgdaDir = process.env.AGDA_DIR;
+  const prevAgdaBin = process.env.AGDA_BIN;
+  process.env.AGDA_DIR = agdaDir;
+  delete process.env.AGDA_BIN;
+
+  const session = new AgdaSession(root);
+  try {
+    const baseline = await session.load("A.agda");
+    expect(baseline.success).toBe(true);
+    expect(baseline.classification).toBe("ok-complete");
+
+    // Break B and push its mtime forward so the rebuild is unambiguous.
+    writeFileSync(join(root, "B.agda"), B_BROKEN);
+    const future = Date.now() / 1000 + 5;
+    utimesSync(join(root, "B.agda"), future, future);
+
+    const reload = await session.load("A.agda");
+    expect(reload.success).toBe(false);
+    expect(reload.classification).toBe("type-error");
+    expect(reload.errors.length).toBeGreaterThan(0);
+  } finally {
+    await session.destroy();
+    if (prevAgdaDir === undefined) delete process.env.AGDA_DIR;
+    else process.env.AGDA_DIR = prevAgdaDir;
+    if (prevAgdaBin !== undefined) process.env.AGDA_BIN = prevAgdaBin;
+  }
+}, 60_000);

--- a/test/unit/agda/session-load-impl.test.ts
+++ b/test/unit/agda/session-load-impl.test.ts
@@ -197,10 +197,10 @@ test("runLoad invalidates prior state and records the attempt on invalid options
   }
 });
 
-test("runLoadNoMetas accepts a clean strict load with no goal-state terminus", async () => {
-  // Cmd_load_no_metas skips the metas display, so a clean strict load
-  // emits no InteractionPoints / AllGoalsWarnings — only highlighting +
-  // Status. That is normal completion, and it must report ok-complete.
+test("runLoadNoMetas accepts a clean strict load reporting an empty goal state", async () => {
+  // The strict load runs over Cmd_load, so a clean file emits the goal-
+  // state terminus (empty InteractionPoints + AllGoalsWarnings with no
+  // goals). That must report ok-complete.
   const root = makeTempRepo();
   const file = "CleanStrict.agda";
   writeFileSync(resolve(root, file), "module CleanStrict where\n", "utf8");
@@ -213,12 +213,7 @@ test("runLoadNoMetas accepts a clean strict load with no goal-state terminus", a
     lastClassification: null,
     lastLoadedAt: null,
     lastInvisibleGoalCount: 0,
-    sendCommand: async () => [
-      { kind: "Status", checked: false },
-      { kind: "ClearRunningInfo" },
-      { kind: "ClearHighlighting" },
-      { kind: "HighlightingInfo", filepath: "/tmp/hl", direct: false },
-    ],
+    sendCommand: async () => cleanLoadResponses(),
     iotcmFor: (_path: string, cmd: string) => cmd,
   } as any;
 
@@ -227,6 +222,39 @@ test("runLoadNoMetas accepts a clean strict load with no goal-state terminus", a
     expect(result.success).toBe(true);
     expect(result.classification).toBe("ok-complete");
     expect(result.hasHoles).toBe(false);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("runLoadNoMetas throws (no false green) when the process ended before the goal state", async () => {
+  // Bug #3: a clean Cmd_load_no_metas emits no terminus, so idle
+  // completion could resolve a still-checking load as ok-complete. The
+  // strict path now runs over Cmd_load and requires the goal-state
+  // terminus — a truncated stream must fail loudly, never report success.
+  const root = makeTempRepo();
+  const file = "TruncatedStrict.agda";
+  writeFileSync(resolve(root, file), "module TruncatedStrict where\n", "utf8");
+
+  const session = {
+    repoRoot: root,
+    currentFile: "/some/previous.agda",
+    goalIds: [3],
+    lastLoadedMtime: 0,
+    lastClassification: "ok-complete",
+    lastLoadedAt: null,
+    lastInvisibleGoalCount: 0,
+    sendCommand: async () => truncatedLoadResponses(),
+    iotcmFor: (_path: string, cmd: string) => cmd,
+  } as any;
+
+  try {
+    await expect(runLoadNoMetas(session, file)).rejects.toThrow(
+      /ended before completing the strict load/i,
+    );
+    // Prior success state was invalidated up front and not restored.
+    expect(session.lastClassification).toBeNull();
+    expect(session.goalIds).toEqual([]);
   } finally {
     rmSync(root, { recursive: true, force: true });
   }

--- a/test/unit/session/agda-transport.test.ts
+++ b/test/unit/session/agda-transport.test.ts
@@ -109,6 +109,66 @@ test("without awaitGoalTerminus a non-load command resolves on the short idle wi
   });
 });
 
+test("inactivity watchdog keeps a steadily-progressing load alive past the timeout window", async () => {
+  // The per-command timeout measures silence, not elapsed time. Here the
+  // 40ms timeout is shorter than the ~120ms the load runs, but progress
+  // arrives every ~15ms (< 40ms), so the watchdog keeps resetting and the
+  // proc is never reaped. An absolute timeout would have killed it mid-load.
+  await withEnv("AGDA_MCP_IDLE_COMPLETION_MS", "5", async () => {
+    const transport = new AgdaTransport();
+    const killCalls: unknown[] = [];
+    const proc = {
+      exitCode: null,
+      signalCode: null,
+      kill(sig?: unknown) { killCalls.push(sig); return true; },
+      stdin: {
+        write() {
+          for (let i = 0; i < 6; i++) {
+            setTimeout(() => transport.handleStdout(Buffer.from('JSON> {"kind":"RunningInfo","message":"Checking"}\n')), i * 15);
+          }
+          setTimeout(() => transport.handleStdout(Buffer.from('JSON> {"kind":"DisplayInfo","info":{"kind":"AllGoalsWarnings","visibleGoals":[],"invisibleGoals":[],"errors":[],"warnings":[]}}\n')), 95);
+          setTimeout(() => transport.handleStdout(Buffer.from('JSON> {"kind":"InteractionPoints","interactionPoints":[]}\n')), 98);
+        },
+      },
+    };
+
+    const responses = await transport.sendCommand(
+      proc as unknown as ChildProcess,
+      'IOTCM "x" NonInteractive Direct (Cmd_load)',
+      40,
+      { awaitGoalTerminus: true },
+    );
+
+    expect(killCalls).toEqual([]);
+    expect(responses.some((r) => r.kind === "InteractionPoints")).toBe(true);
+  });
+});
+
+test("a fatal protocol stderr completes a load instead of hanging until timeout", async () => {
+  // A malformed IOTCM makes Agda print `cannot read:` and keep running with
+  // no goal state. Without treating it as a terminus the load would wait the
+  // full timeout; here it must resolve on the idle window with that notice.
+  await withEnv("AGDA_MCP_IDLE_COMPLETION_MS", "5", async () => {
+    const transport = new AgdaTransport();
+    const proc = {
+      stdin: {
+        write() {
+          setTimeout(() => transport.handleStdout(Buffer.from('JSON> cannot read: IOTCM "x" None Direct bad\n')), 0);
+        },
+      },
+    };
+
+    const responses = await transport.sendCommand(
+      proc as unknown as ChildProcess,
+      'IOTCM "x" NonInteractive Direct (Cmd_load)',
+      2000,
+      { awaitGoalTerminus: true },
+    );
+
+    expect(responses.some((r) => r.kind === "StderrOutput")).toBe(true);
+  });
+});
+
 test("AgdaTransport resolves after trailing Status when earlier payloads already arrived", async () => {
   await withEnv("AGDA_MCP_IDLE_COMPLETION_MS", "5", async () => {
     const transport = new AgdaTransport();

--- a/test/unit/session/goal-terminus.test.ts
+++ b/test/unit/session/goal-terminus.test.ts
@@ -22,6 +22,20 @@ test("reached() short-circuits on a DisplayInfo Error", () => {
   expect(t.reached()).toBe(true);
 });
 
+test("reached() short-circuits on a fatal protocol stderr", () => {
+  const t = new GoalTerminusTracker();
+  // Agda rejects a malformed IOTCM on the JSON> channel and keeps
+  // running with no goal state — must still count as a terminus.
+  t.record({ kind: "StderrOutput", text: 'cannot read: IOTCM "X" None Direct bad' } as never);
+  expect(t.reached()).toBe(true);
+});
+
+test("reached() ignores benign stderr notices", () => {
+  const t = new GoalTerminusTracker();
+  t.record({ kind: "StderrOutput", text: "Checking Foo (/tmp/Foo.agda)." } as never);
+  expect(t.reached()).toBe(false);
+});
+
 test("progress/highlighting responses are never a terminus", () => {
   const t = new GoalTerminusTracker();
   for (const kind of ["Status", "RunningInfo", "HighlightingInfo", "ClearHighlighting", "ClearRunningInfo"]) {


### PR DESCRIPTION
Follow-on hardening to the goal-state completion work in #68, targeting v0.6.8. Ready for review.

## What this fixes

Three defects surfaced by adversarial analysis of #68, each empirically confirmed against pinned Agda via the `--interaction-json` protocol:

1. **Fatal-stderr hang.** A malformed IOTCM (or one Agda "cannot read") is answered on the JSON channel with `cannot read: …` and *no* goal state — but the process stays alive. With #68's goal-state wait, the load then stalled the full per-command timeout before failing. A fatal protocol stderr (`cannot read:`, `failed to parse`, `invalid …`) is now a load terminus, so it fails fast with Agda's own message. Adds a shared `isFatalProtocolStderr` predicate.

2. **Absolute-timeout kills healthy loads.** The per-command timeout was an absolute deadline from command start, so a cold load still streaming `RunningInfo` at the deadline was killed and respawned. It's now an **inactivity watchdog** that resets on each response — a wedged process is still reaped; a slow-but-progressing load is not. Adds `command-wait-diagnostics.ts` (shared sentry/timeout diagnostic shape).

3. **`agda_load_no_metas` strict false-green.** A clean `Cmd_load_no_metas` emits **no goal-state terminus at all** — only a `Checking <module>` line, then silence until it finishes (confirmed: silent through a multi-second forced normalization). So its completion could only be inferred from the idle gap, and a module that type-checks silently for longer resolved mid-check as `ok-complete`, hiding holes/errors past the pause. The strict load now runs over `Cmd_load` (which always emits `InteractionPoints` + `AllGoalsWarnings`, or an `Error`) and applies the same strict rejection — any hole or unsolved meta ⇒ `type-error` — at the classification layer. Pass/fail contract is unchanged; completion now waits for Agda's real goal state.

## Stale-dependency false-green (issues #61, #64) — reproduced and fixed

Driving **this** build vs the installed **0.6.7** against a stale broken dependency (load A→B clean, break B on disk, reload A):

- **0.6.7 (what the downstream repo runs today):** reload reports `ok-complete / success:true` — **false green**, on both direct and transitive (A→B→C) breaks.
- **this branch:** correctly reports `type-error`.

The race only triggers when the dependency's rebuild is **slow and silent** (Agda streams `Checking <dep>` then goes quiet for seconds) — which is why simple fast local repros never caught it. New gated integration test `agda-stale-dependency.test.ts` reproduces it with a deliberately slow, silent rebuild.

## Validation

- New unit coverage: fatal-stderr terminus; inactivity watchdog keeps a steadily-progressing load alive past the window; strict load throws (no false-green) on a truncated stream and reports `ok-complete` on a real empty goal state.
- New gated integration test for the #61/#64 stale-dependency race.
- Full suite green (1363 passed / 153 skipped); all real-Agda load integration tests pass under `RUN_AGDA_INTEGRATION=1`.
- Exercised the local build against a large downstream Agda codebase: strict + non-strict loads classify correctly on real modules; a 16-tool interactive sweep (goal type/context, give, refine, case-split, auto, compute/infer, queries) is 100% clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)